### PR TITLE
add join_date column to members table and integrate across views

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,4 +27,4 @@ B2_REGION=us-west-004
 B2_BUCKET=ysh-gallery
 B2_KEY_ID=your-application-key-id
 B2_APP_KEY=your-application-key
-B2_PUBLIC_URL=https://f005.backblazeb2.com/file/ysh-gallery
+B2_PUBLIC_URL=https://f002.backblazeb2.com/file/ysh-gallery

--- a/db/migrate.js
+++ b/db/migrate.js
@@ -160,6 +160,18 @@ async function migrate() {
     await db.exec('DROP TABLE admins');
   }
 
+  // Add join_date column to track when members joined the organization
+  // Note: SQLite ALTER TABLE doesn't support DEFAULT with functions, so we add without default
+  // and set values manually. New inserts will use the schema default from SCHEMA constant.
+  try {
+    await db.exec("ALTER TABLE members ADD COLUMN join_date TEXT");
+    // For existing members, set join_date to created_at for backward compatibility
+    await db.exec("UPDATE members SET join_date = created_at WHERE join_date IS NULL");
+    logger.info('Added join_date column to members table');
+  } catch (_e) {
+    // Column already exists
+  }
+
   logger.info('Database migration complete');
 }
 

--- a/db/repos/members.js
+++ b/db/repos/members.js
@@ -12,19 +12,19 @@ async function findAdminByEmail(email) {
   return await db.get('SELECT * FROM members WHERE email = ? AND role IS NOT NULL', email);
 }
 
-async function create({ member_number, first_name, last_name, email, phone, address_street, address_city, address_state, address_zip, membership_year, status, notes }) {
+async function create({ member_number, first_name, last_name, email, phone, address_street, address_city, address_state, address_zip, membership_year, join_date, status, notes }) {
   return await db.run(
-    `INSERT INTO members (member_number, first_name, last_name, email, phone, address_street, address_city, address_state, address_zip, membership_year, status, notes)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    member_number, first_name, last_name, email, phone || null, address_street || null, address_city || null, address_state || null, address_zip || null, membership_year, status || 'pending', notes || null
+    `INSERT INTO members (member_number, first_name, last_name, email, phone, address_street, address_city, address_state, address_zip, membership_year, join_date, status, notes)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?)`,
+    member_number, first_name, last_name, email, phone || null, address_street || null, address_city || null, address_state || null, address_zip || null, membership_year, join_date || null, status || 'pending', notes || null
   );
 }
 
-async function update(id, { first_name, last_name, email, phone, address_street, address_city, address_state, address_zip, membership_year, status, notes }) {
+async function update(id, { first_name, last_name, email, phone, address_street, address_city, address_state, address_zip, membership_year, join_date, status, notes }) {
   return await db.run(
-    `UPDATE members SET first_name=?, last_name=?, email=?, phone=?, address_street=?, address_city=?, address_state=?, address_zip=?, membership_year=?, status=?, notes=?, updated_at=datetime('now')
+    `UPDATE members SET first_name=?, last_name=?, email=?, phone=?, address_street=?, address_city=?, address_state=?, address_zip=?, membership_year=?, join_date=?, status=?, notes=?, updated_at=datetime('now')
      WHERE id=?`,
-    first_name, last_name, email, phone || null, address_street || null, address_city || null, address_state || null, address_zip || null, membership_year, status, notes || null, id
+    first_name, last_name, email, phone || null, address_street || null, address_city || null, address_state || null, address_zip || null, membership_year, join_date || null, status, notes || null, id
   );
 }
 
@@ -144,12 +144,12 @@ async function createWithFamily({ primaryMember, familyMembers = [], membershipT
     const primaryResult = await db.run(
       `INSERT INTO members (member_number, first_name, last_name, email, phone,
         address_street, address_city, address_state, address_zip,
-        membership_year, status, membership_type)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        membership_year, join_date, status, membership_type)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?)`,
       [primaryMemberNumber, primaryMember.first_name, primaryMember.last_name,
        primaryMember.email, primaryMember.phone || null, primaryMember.address_street || null,
        primaryMember.address_city || null, primaryMember.address_state || null, primaryMember.address_zip || null,
-       year, 'pending', membershipType]
+       year, primaryMember.join_date || null, 'pending', membershipType]
     );
 
     const primaryId = primaryResult.lastInsertRowid;

--- a/db/schema.js
+++ b/db/schema.js
@@ -24,6 +24,7 @@ const SCHEMA = `
     otp_hash TEXT,
     otp_expires_at TEXT,
     otp_attempts INTEGER NOT NULL DEFAULT 0,
+    join_date TEXT DEFAULT (datetime('now')),
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT (datetime('now'))
   );

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -188,10 +188,11 @@ router.post('/members', async (req, res) => {
     membership_type = 'individual',
     first_name, last_name, email, phone,
     address_street, address_city, address_state, address_zip,
-    membership_year, status, notes
+    membership_year, join_date, status, notes
   } = req.body;
 
   const year = membership_year || new Date().getFullYear();
+  const normalizedJoinDate = join_date?.trim() || undefined;
 
   try {
     if (membership_type === 'family') {
@@ -212,7 +213,8 @@ router.post('/members', async (req, res) => {
       await memberRepo.createWithFamily({
         primaryMember: {
           first_name, last_name, email, phone,
-          address_street, address_city, address_state, address_zip
+          address_street, address_city, address_state, address_zip,
+          join_date: normalizedJoinDate
         },
         familyMembers,
         membershipType: 'family'
@@ -240,7 +242,7 @@ router.post('/members', async (req, res) => {
       await memberRepo.create({
         member_number, first_name, last_name, email, phone,
         address_street, address_city, address_state, address_zip,
-        membership_year: year, status: status || 'pending', notes,
+        membership_year: year, join_date: normalizedJoinDate, status: status || 'pending', notes,
       });
 
       req.session.flash_success = `Member ${first_name} ${last_name} created.`;
@@ -290,12 +292,13 @@ router.get('/members/:id', async (req, res, next) => {
 });
 
 router.post('/members/:id', async (req, res) => {
-  const { first_name, last_name, email, phone, address_street, address_city, address_state, address_zip, membership_year, status, notes } = req.body;
+  const { first_name, last_name, email, phone, address_street, address_city, address_state, address_zip, membership_year, join_date, status, notes } = req.body;
+  const normalizedJoinDate = join_date?.trim() || undefined;
   try {
     await memberRepo.update(req.params.id, {
       first_name, last_name, email, phone,
       address_street, address_city, address_state, address_zip,
-      membership_year, status, notes,
+      membership_year, join_date: normalizedJoinDate, status, notes,
     });
     req.session.flash_success = 'Member updated.';
   } catch (e) {

--- a/test/services/storage.test.js
+++ b/test/services/storage.test.js
@@ -14,7 +14,7 @@ const B2_ENV = {
   B2_BUCKET: 'ysh-gallery',
   B2_KEY_ID: 'test-key-id',
   B2_APP_KEY: 'test-app-key',
-  B2_PUBLIC_URL: 'https://f005.backblazeb2.com/file/ysh-gallery',
+  B2_PUBLIC_URL: 'https://f002.backblazeb2.com/file/ysh-gallery',
 };
 
 let storage;
@@ -75,7 +75,7 @@ describe('uploadFile', () => {
 
   test('returns public URL', async () => {
     const url = await storage.uploadFile(Buffer.from('data'), 'test.png', 'bios');
-    expect(url).toMatch(/^https:\/\/f005\.backblazeb2\.com\/file\/ysh-gallery\/bios\/\d+-[a-f0-9]+\.png$/);
+    expect(url).toMatch(/^https:\/\/f002\.backblazeb2\.com\/file\/ysh-gallery\/bios\/\d+-[a-f0-9]+\.png$/);
   });
 
   test('generates unique filenames', async () => {
@@ -111,7 +111,7 @@ describe('uploadFile', () => {
 
 describe('deleteFile', () => {
   test('sends DeleteObjectCommand for B2 URLs', async () => {
-    await storage.deleteFile('https://f005.backblazeb2.com/file/ysh-gallery/gallery/123-abc.jpg');
+    await storage.deleteFile('https://f002.backblazeb2.com/file/ysh-gallery/gallery/123-abc.jpg');
 
     expect(DeleteObjectCommand).toHaveBeenCalledWith({
       Bucket: 'ysh-gallery',
@@ -142,14 +142,14 @@ describe('deleteFile', () => {
 
   test('skips when B2 is not configured', async () => {
     delete process.env.B2_BUCKET;
-    await storage.deleteFile('https://f005.backblazeb2.com/file/ysh-gallery/gallery/123.jpg');
+    await storage.deleteFile('https://f002.backblazeb2.com/file/ysh-gallery/gallery/123.jpg');
     expect(mockSend).not.toHaveBeenCalled();
   });
 
   test('propagates S3 errors', async () => {
     mockSend.mockRejectedValueOnce(new Error('Delete failed'));
     await expect(
-      storage.deleteFile('https://f005.backblazeb2.com/file/ysh-gallery/gallery/123.jpg')
+      storage.deleteFile('https://f002.backblazeb2.com/file/ysh-gallery/gallery/123.jpg')
     ).rejects.toThrow('Delete failed');
   });
 });

--- a/views/admin/members/form.pug
+++ b/views/admin/members/form.pug
@@ -48,6 +48,9 @@ block content
         label(for="membership_year") Membership Year
         input#membership_year(type="number" name="membership_year" value=(member ? member.membership_year : new Date().getFullYear()))
       .form-group
+        label(for="join_date") Join Date
+        input#join_date(type="date" name="join_date" value=(member && member.join_date ? member.join_date.split(' ')[0] : ''))
+      .form-group
         label(for="status") Status
         select#status(name="status")
           option(value="pending" selected=(member && member.status === 'pending')) Pending

--- a/views/admin/members/view.pug
+++ b/views/admin/members/view.pug
@@ -27,6 +27,9 @@ block content
           th Year
           td= member.membership_year
         tr
+          th Join Date
+          td= formatDate(member.join_date)
+        tr
           th Status
           td
             span(class=`badge badge-${member.status}`)= member.status


### PR DESCRIPTION
This pull request introduces a new `join_date` field to the `members` table, allowing the application to track when each member joined the organization. The migration ensures backward compatibility by populating `join_date` for existing records, updates all relevant database operations and forms to handle the new field, and adjusts tests and configuration for a Backblaze B2 public URL change.

**Database schema and migration:**

* Added a `join_date` column to the `members` table, defaulting to the current datetime for new records, and backfilled existing records with their `created_at` value. [[1]](diffhunk://#diff-ea1f9f5c287ef6d5053b18d7b6f744140affb15d8f0c56b8f43a3e68b9cf99acR27) [[2]](diffhunk://#diff-d4607071c2204a224313444726bab1d792e07ae19edcef5e8f7002d005c94a47R163-R174)

**Repository and API changes:**

* Updated member creation and update logic in `db/repos/members.js` and `routes/admin.js` to support reading, writing, and normalizing the `join_date` field for both individual and family memberships. [[1]](diffhunk://#diff-44a8d7fa3ee6169f36599e6024982760c93bbb888f019ebf3c0a7af4466e614cL15-R27) [[2]](diffhunk://#diff-44a8d7fa3ee6169f36599e6024982760c93bbb888f019ebf3c0a7af4466e614cL147-R152) [[3]](diffhunk://#diff-412b886e92038144a95017757984786fec69eb98c8b8476114a1aa84fb6700edL191-R195) [[4]](diffhunk://#diff-412b886e92038144a95017757984786fec69eb98c8b8476114a1aa84fb6700edL215-R217) [[5]](diffhunk://#diff-412b886e92038144a95017757984786fec69eb98c8b8476114a1aa84fb6700edL243-R245) [[6]](diffhunk://#diff-412b886e92038144a95017757984786fec69eb98c8b8476114a1aa84fb6700edL293-R301)

**Admin UI improvements:**

* Added `join_date` input to the member form and display of `join_date` in the member view page. [[1]](diffhunk://#diff-30eec42b862ec1e80fd373e6ed0fa7173b5ff0c3d033f37e6448a25384076cd7R50-R52) [[2]](diffhunk://#diff-43a2c30a3cce62d219d850dbfc9c92ba1663b73066cbd1fd5e773badaefa09a1R29-R31)

**Configuration and test updates:**

* Changed Backblaze B2 public URL from `f005` to `f002` in environment files and updated all related test cases to use the new URL. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL30-R30) [[2]](diffhunk://#diff-bcab69cf1385a19b980d6383d8d24866c09dc5278c932da52c8b20374187043cL17-R17) [[3]](diffhunk://#diff-bcab69cf1385a19b980d6383d8d24866c09dc5278c932da52c8b20374187043cL78-R78) [[4]](diffhunk://#diff-bcab69cf1385a19b980d6383d8d24866c09dc5278c932da52c8b20374187043cL114-R114) [[5]](diffhunk://#diff-bcab69cf1385a19b980d6383d8d24866c09dc5278c932da52c8b20374187043cL145-R152)