### PR TITLE
add support for B2 storage integration for card uploads and emails

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -336,6 +336,9 @@ router.post('/members/:id/card', async (req, res) => {
 router.get('/members/:id/card/pdf', async (req, res) => {
   const card = await cardsRepo.findLatestByMemberId(req.params.id);
   if (!card || !card.pdf_path) { req.session.flash_error = 'No card found.'; return res.redirect(`/admin/members/${req.params.id}`); }
+  if (card.pdf_path.startsWith('http')) {
+    return res.redirect(card.pdf_path);
+  }
   const cardsDir = path.resolve(__dirname, '..', 'data', 'cards');
   const resolved = path.resolve(__dirname, '..', card.pdf_path);
   if (!resolved.startsWith(cardsDir + path.sep) && resolved !== cardsDir) {
@@ -347,6 +350,9 @@ router.get('/members/:id/card/pdf', async (req, res) => {
 router.get('/members/:id/card/png', async (req, res) => {
   const card = await cardsRepo.findLatestByMemberId(req.params.id);
   if (!card || !card.png_path) { req.session.flash_error = 'No card found.'; return res.redirect(`/admin/members/${req.params.id}`); }
+  if (card.png_path.startsWith('http')) {
+    return res.redirect(card.png_path);
+  }
   const cardsDir = path.resolve(__dirname, '..', 'data', 'cards');
   const resolved = path.resolve(__dirname, '..', card.png_path);
   if (!resolved.startsWith(cardsDir + path.sep) && resolved !== cardsDir) {

--- a/services/storage.js
+++ b/services/storage.js
@@ -49,6 +49,17 @@ async function deleteFile(fileUrl) {
   }));
 }
 
+async function uploadFileAtKey(buffer, key, contentType) {
+    const client = getClient();
+    await client.send(new PutObjectCommand({
+        Bucket: process.env.B2_BUCKET,
+        Key: key,
+        Body: buffer,
+        ContentType: contentType,
+    }));
+    return `${process.env.B2_PUBLIC_URL}/${key}`;
+}
+
 function mimeFromExt(ext) {
   const types = {
     '.jpg': 'image/jpeg',
@@ -56,8 +67,9 @@ function mimeFromExt(ext) {
     '.png': 'image/png',
     '.gif': 'image/gif',
     '.webp': 'image/webp',
+      '.pdf': 'application/pdf',
   };
   return types[ext.toLowerCase()] || 'application/octet-stream';
 }
 
-module.exports = { uploadFile, deleteFile, isConfigured };
+module.exports = {uploadFile, uploadFileAtKey, deleteFile, isConfigured};

--- a/test/services/storage.test.js
+++ b/test/services/storage.test.js
@@ -109,6 +109,33 @@ describe('uploadFile', () => {
   });
 });
 
+describe('uploadFileAtKey', () => {
+    test('sends PutObjectCommand with specified key and content type', async () => {
+        const buffer = Buffer.from('pdf-data');
+        await storage.uploadFileAtKey(buffer, 'cards/card-1-2025.pdf', 'application/pdf');
+
+        expect(PutObjectCommand).toHaveBeenCalledWith({
+            Bucket: 'ysh-gallery',
+            Key: 'cards/card-1-2025.pdf',
+            Body: buffer,
+            ContentType: 'application/pdf',
+        });
+        expect(mockSend).toHaveBeenCalled();
+    });
+
+    test('returns public URL with the given key', async () => {
+        const url = await storage.uploadFileAtKey(Buffer.from('x'), 'cards/card-1-2025.png', 'image/png');
+        expect(url).toBe('https://f002.backblazeb2.com/file/ysh-gallery/cards/card-1-2025.png');
+    });
+
+    test('propagates S3 errors', async () => {
+        mockSend.mockRejectedValueOnce(new Error('B2 failure'));
+        await expect(
+            storage.uploadFileAtKey(Buffer.from('x'), 'cards/card.pdf', 'application/pdf')
+        ).rejects.toThrow('B2 failure');
+    });
+});
+
 describe('deleteFile', () => {
   test('sends DeleteObjectCommand for B2 URLs', async () => {
     await storage.deleteFile('https://f002.backblazeb2.com/file/ysh-gallery/gallery/123-abc.jpg');


### PR DESCRIPTION
This pull request adds support for storing membership card images (PDF and PNG) in remote storage (Backblaze B2) in addition to the existing local file storage. The code now dynamically uploads card files to B2 when configured, stores their URLs in the database, and serves or emails them from either local disk or B2 as appropriate. Comprehensive tests are included to verify both local and remote workflows.

Key changes include:

**Remote Storage Integration for Card Generation:**
- Updated `generatePNG` and `generatePDF` in `services/card.js` to upload files to B2 using a new `uploadFileAtKey` method when remote storage is configured, saving the resulting URL in the database instead of a local file path. Falls back to local storage if B2 is not configured. [[1]](diffhunk://#diff-3f96f36b7ec72985e246ca94fef3f4fe4c1fe055504e6d4f9c1288858740ea12L85-R117) [[2]](diffhunk://#diff-3f96f36b7ec72985e246ca94fef3f4fe4c1fe055504e6d4f9c1288858740ea12R154-R167)
- Added the `uploadFileAtKey` method to `services/storage.js`, which uploads a buffer to a deterministic key in B2 and returns the public URL.

**Dynamic File Serving and Emailing:**
- Modified admin routes in `routes/admin.js` to redirect to B2 URLs for card files if the database path is an HTTP URL, otherwise serve from local disk. [[1]](diffhunk://#diff-412b886e92038144a95017757984786fec69eb98c8b8476114a1aa84fb6700edR339-R341) [[2]](diffhunk://#diff-412b886e92038144a95017757984786fec69eb98c8b8476114a1aa84fb6700edR353-R355)
- Updated `sendCardEmail` in `services/email.js` to fetch card files from B2 URLs when present, or from disk otherwise, for email attachments.

**Testing and Test Infrastructure:**
- Added and extended tests in `test/services/card.test.js` to cover both local and B2 workflows for card generation, verifying correct file uploads, DB updates, and return values. [[1]](diffhunk://#diff-5e37c3f91d3348326f9ff7d0d6d342b54f1a791ac49836a88a0f02b1e236f876R153-L155) [[2]](diffhunk://#diff-5e37c3f91d3348326f9ff7d0d6d342b54f1a791ac49836a88a0f02b1e236f876R225-R266)
- Added tests in `test/services/email.test.js` for sending emails with card attachments fetched from B2 URLs, including error handling when fetch fails.
- Added tests for the new `uploadFileAtKey` method in `test/services/storage.test.js`.

These changes ensure seamless support for both local and cloud storage of membership cards, improving scalability and flexibility.