### PR TITLE
fixes #36 by handling `join_date` formatting in admin member templates

### DIFF
--- a/middleware/locals.js
+++ b/middleware/locals.js
@@ -30,7 +30,7 @@ async function injectLocals(req, res, next) {
         return date.toISOString().split('T')[0];
       }
       if (typeof date === 'string') {
-        return date.split('T')[0];
+          return date.split('T')[0].split(' ')[0];
       }
       return '';
     };

--- a/robot/tests/admin_members.robot
+++ b/robot/tests/admin_members.robot
@@ -58,3 +58,23 @@ Members Search
     Get Text    .admin-table    contains    Alice Findable
     ${page_text}=    Get Text    .admin-table
     Should Not Contain    ${page_text}    Bob Hidden
+
+Edit Member Form Loads Without Error
+    [Documentation]    Navigating to the edit form must render the form, not a 500.
+    ...    Regression for: edit on member profile throws 500 when join_date is a
+    ...    PostgreSQL Date object instead of a plain string.
+    ${id}=    Seed Member    first_name=Editable    last_name=Member    email=editable@example.com
+    Login As Admin
+    Navigate To    /admin/members/${id}?edit=1
+    Wait For Elements State    input[name="first_name"]    visible    timeout=10s
+    Get Text    h1.admin-page-title    contains    Edit Member
+
+Edit Member Updates Fields
+    ${id}=    Seed Member    first_name=Before    last_name=Edit    email=before.edit@example.com
+    Login As Admin
+    Navigate To    /admin/members/${id}?edit=1
+    Wait For Elements State    input[name="first_name"]    visible    timeout=10s
+    Fill Text    input[name="first_name"]    After
+    Submit Admin Form
+    Flash Success Should Be Visible    updated
+    Get Text    .detail-table    contains    After Edit

--- a/test/middleware/locals.test.js
+++ b/test/middleware/locals.test.js
@@ -114,3 +114,37 @@ describe('injectLocals middleware', () => {
     expect(next).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('formatDate helper', () => {
+  let formatDate;
+
+  beforeEach(async () => {
+    const res = buildRes();
+    await injectLocals(buildReq(), res, jest.fn());
+    formatDate = res.locals.formatDate;
+  });
+
+  test('returns empty string for null', () => {
+    expect(formatDate(null)).toBe('');
+  });
+
+  test('returns empty string for undefined', () => {
+    expect(formatDate(undefined)).toBe('');
+  });
+
+  test('formats a Date object to YYYY-MM-DD', () => {
+    expect(formatDate(new Date('2024-01-15T12:00:00Z'))).toBe('2024-01-15');
+  });
+
+  test('formats an ISO datetime string to YYYY-MM-DD', () => {
+    expect(formatDate('2024-01-15T12:34:56Z')).toBe('2024-01-15');
+  });
+
+  test('formats a SQLite datetime string (space separator) to YYYY-MM-DD', () => {
+    expect(formatDate('2024-01-15 12:34:56')).toBe('2024-01-15');
+  });
+
+  test('returns a plain date string unchanged', () => {
+    expect(formatDate('2024-01-15')).toBe('2024-01-15');
+  });
+});

--- a/test/routes/admin-members.test.js
+++ b/test/routes/admin-members.test.js
@@ -1,0 +1,80 @@
+const pug = require('pug');
+const path = require('path');
+
+const FORM_TEMPLATE = path.resolve(__dirname, '../../views/admin/members/form.pug');
+
+// Fixed-version formatDate that handles Date objects, ISO strings, and SQLite
+// space-separated timestamps. This mirrors the expected post-fix behavior of
+// middleware/locals.js so that the template test isolates template correctness.
+function formatDate(date) {
+    if (!date) return '';
+    if (date instanceof Date) return date.toISOString().split('T')[0];
+    if (typeof date === 'string') return date.split('T')[0].split(' ')[0];
+    return '';
+}
+
+function renderEditForm(memberOverrides = {}) {
+    const member = {
+        id: 1,
+        first_name: 'Test',
+        last_name: 'Member',
+        email: 'test@example.com',
+        phone: '555-1234',
+        address_street: '123 Main St',
+        address_city: 'Billings',
+        address_state: 'MT',
+        address_zip: '59101',
+        membership_year: 2026,
+        status: 'active',
+        notes: null,
+        join_date: null,
+        ...memberOverrides,
+    };
+    return pug.renderFile(FORM_TEMPLATE, {
+        member,
+        formatDate,
+        csrfToken: 'test-token',
+        flash_success: null,
+        flash_error: null,
+        currentPath: `/admin/members/${member.id}`,
+        isAdmin: true,
+        adminRole: 'super_admin',
+        site: {},
+    });
+}
+
+describe('admin member edit form template', () => {
+    test('renders without error when join_date is null', () => {
+        expect(() => renderEditForm({join_date: null})).not.toThrow();
+    });
+
+    test('renders without error when join_date is a plain date string', () => {
+        expect(() => renderEditForm({join_date: '2024-01-15'})).not.toThrow();
+    });
+
+    test('renders without error when join_date is a SQLite datetime string', () => {
+        expect(() => renderEditForm({join_date: '2024-01-15 12:34:56'})).not.toThrow();
+    });
+
+    test('renders without error when join_date is a Date object (as returned by PostgreSQL)', () => {
+        // This test fails before the fix: form.pug calls join_date.split(' ') which
+        // throws TypeError on a Date object, causing a 500 in production (PostgreSQL).
+        expect(() => renderEditForm({join_date: new Date('2024-01-15T00:00:00Z')})).not.toThrow();
+    });
+
+    test('date input value is YYYY-MM-DD when join_date is a Date object', () => {
+        const html = renderEditForm({join_date: new Date('2024-01-15T00:00:00Z')});
+        expect(html).toContain('value="2024-01-15"');
+    });
+
+    test('date input value is YYYY-MM-DD when join_date is a SQLite datetime string', () => {
+        const html = renderEditForm({join_date: '2024-01-15 12:34:56'});
+        expect(html).toContain('value="2024-01-15"');
+    });
+
+    test('date input is empty when join_date is null', () => {
+        const html = renderEditForm({join_date: null});
+        expect(html).toContain('name="join_date"');
+        expect(html).not.toContain('value="2024');
+    });
+});

--- a/views/admin/members/form.pug
+++ b/views/admin/members/form.pug
@@ -49,7 +49,7 @@ block content
         input#membership_year(type="number" name="membership_year" value=(member ? member.membership_year : new Date().getFullYear()))
       .form-group
         label(for="join_date") Join Date
-        input#join_date(type="date" name="join_date" value=(member && member.join_date ? member.join_date.split(' ')[0] : ''))
+        input#join_date(type="date" name="join_date" value=(member && member.join_date ? formatDate(member.join_date) : ''))
       .form-group
         label(for="status") Status
         select#status(name="status")


### PR DESCRIPTION
#Overview
Ensure `join_date` values are correctly formatted in admin member edit form templates to prevent rendering errors for PostgreSQL `Date` objects or SQLite datetime strings. Added regression tests for robustness.

## Checklist
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] No `.env` or secrets committed
