### PR TITLE
add lifetime member flag, fix family email renewal bug, and misc fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 node_modules/
 .env
 data/

--- a/db/migrate.js
+++ b/db/migrate.js
@@ -42,6 +42,7 @@ async function migrate() {
       "ALTER TABLE emails_log ADD COLUMN IF NOT EXISTS created_by INTEGER REFERENCES members(id) ON DELETE SET NULL",
       "ALTER TABLE membership_cards ADD COLUMN IF NOT EXISTS created_by INTEGER REFERENCES members(id) ON DELETE SET NULL",
       "ALTER TABLE membership_periods ADD COLUMN IF NOT EXISTS card_template_path TEXT",
+      "ALTER TABLE members ADD COLUMN IF NOT EXISTS is_lifetime INTEGER NOT NULL DEFAULT 0",
     ];
     for (const sql of pgAlters) {
       await db.exec(sql);
@@ -298,6 +299,7 @@ async function migrate() {
     "ALTER TABLE emails_log ADD COLUMN created_by INTEGER REFERENCES members(id) ON DELETE SET NULL",
     "ALTER TABLE membership_cards ADD COLUMN created_by INTEGER REFERENCES members(id) ON DELETE SET NULL",
     "ALTER TABLE membership_periods ADD COLUMN card_template_path TEXT",
+    "ALTER TABLE members ADD COLUMN is_lifetime INTEGER NOT NULL DEFAULT 0",
   ];
   for (const sql of auditAlters) {
     try {

--- a/db/repos/members.js
+++ b/db/repos/members.js
@@ -7,21 +7,26 @@ async function findById(id) {
 }
 
 async function findByEmail(email) {
-  return await db.get('SELECT * FROM members WHERE email = ?', email);
+  // Prefer primary members (primary_member_id IS NULL) so family primaries are
+  // returned before sub-members who may share the same email address.
+  return await db.get(
+    'SELECT * FROM members WHERE email = ? ORDER BY primary_member_id IS NULL DESC LIMIT 1',
+    email
+  );
 }
 
 async function findAdminByEmail(email) {
   return await db.get('SELECT * FROM members WHERE email = ? AND role IS NOT NULL', email);
 }
 
-async function create({ member_number, first_name, last_name, email, phone, address_street, address_city, address_state, address_zip, membership_year, join_date, status, notes }) {
+async function create({ member_number, first_name, last_name, email, phone, address_street, address_city, address_state, address_zip, membership_year, join_date, status, is_lifetime, notes }) {
     const actor = getActor();
     const result = await db.run(
         `INSERT INTO members (member_number, first_name, last_name, email, phone, address_street, address_city,
-                              address_state, address_zip, membership_year, join_date, status, notes, created_by,
+                              address_state, address_zip, membership_year, join_date, status, is_lifetime, notes, created_by,
                               updated_by)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?, ?, ?)`,
-        member_number, first_name, last_name, email, phone || null, address_street || null, address_city || null, address_state || null, address_zip || null, membership_year, join_date || null, status || 'pending', notes || null, actor.id || null, actor.id || null
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')), ?, ?, ?, ?, ?)`,
+        member_number, first_name, last_name, email, phone || null, address_street || null, address_city || null, address_state || null, address_zip || null, membership_year, join_date || null, status || 'pending', is_lifetime ? 1 : 0, notes || null, actor.id || null, actor.id || null
   );
     const row = await db.get('SELECT * FROM members WHERE id = ?', result.lastInsertRowid);
     await auditLog.insert({
@@ -35,13 +40,13 @@ async function create({ member_number, first_name, last_name, email, phone, addr
     return result;
 }
 
-async function update(id, { first_name, last_name, email, phone, address_street, address_city, address_state, address_zip, membership_year, join_date, status, notes }) {
+async function update(id, { first_name, last_name, email, phone, address_street, address_city, address_state, address_zip, membership_year, join_date, status, is_lifetime, notes }) {
     const actor = getActor();
     const old = await db.get('SELECT * FROM members WHERE id = ?', id);
     const result = await db.run(
-        `UPDATE members SET first_name=?, last_name=?, email=?, phone=?, address_street=?, address_city=?, address_state=?, address_zip=?, membership_year=?, join_date=?, status=?, notes=?, updated_at=datetime('now'), updated_by=?
+        `UPDATE members SET first_name=?, last_name=?, email=?, phone=?, address_street=?, address_city=?, address_state=?, address_zip=?, membership_year=?, join_date=?, status=?, is_lifetime=?, notes=?, updated_at=datetime('now'), updated_by=?
      WHERE id=?`,
-        first_name, last_name, email, phone || null, address_street || null, address_city || null, address_state || null, address_zip || null, membership_year, join_date || null, status, notes || null, actor.id || null, id
+        first_name, last_name, email, phone || null, address_street || null, address_city || null, address_state || null, address_zip || null, membership_year, join_date || null, status, is_lifetime ? 1 : 0, notes || null, actor.id || null, id
   );
     const row = await db.get('SELECT * FROM members WHERE id = ?', id);
     await auditLog.insert({
@@ -226,6 +231,7 @@ async function findNeedingRenewal(currentPeriodId, daysUntilExpiry) {
         `SELECT *
          FROM members
          WHERE primary_member_id IS NULL
+           AND is_lifetime = 0
            AND status IN ('active', 'expired')
            AND expiry_date IS NOT NULL
            AND NOT EXISTS (

--- a/db/repos/members.js
+++ b/db/repos/members.js
@@ -46,7 +46,7 @@ async function update(id, { first_name, last_name, email, phone, address_street,
     const result = await db.run(
         `UPDATE members SET first_name=?, last_name=?, email=?, phone=?, address_street=?, address_city=?, address_state=?, address_zip=?, membership_year=?, join_date=?, status=?, is_lifetime=?, notes=?, updated_at=datetime('now'), updated_by=?
      WHERE id=?`,
-        first_name, last_name, email, phone || null, address_street || null, address_city || null, address_state || null, address_zip || null, membership_year, join_date || null, status, is_lifetime ? 1 : 0, notes || null, actor.id || null, id
+        first_name, last_name, email, phone || null, address_street || null, address_city || null, address_state || null, address_zip || null, membership_year, join_date || null, status, is_lifetime !== undefined ? (is_lifetime ? 1 : 0) : (old.is_lifetime ?? 0), notes || null, actor.id || null, id
   );
     const row = await db.get('SELECT * FROM members WHERE id = ?', id);
     await auditLog.insert({

--- a/db/schema.js
+++ b/db/schema.js
@@ -19,6 +19,7 @@ const SCHEMA = `
     membership_type TEXT NOT NULL DEFAULT 'individual' CHECK(membership_type IN ('individual','family')),
     primary_member_id INTEGER REFERENCES members(id) ON DELETE CASCADE,
     status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','active','expired','cancelled')),
+    is_lifetime INTEGER NOT NULL DEFAULT 0,
     notes TEXT,
     role TEXT CHECK(role IN ('super_admin','editor')),
     otp_hash TEXT,

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -292,6 +292,13 @@
   border: 1px solid #d6d8db;
 }
 
+.badge-lifetime {
+  background: #e8d5f5;
+  color: #5a1a8a;
+  border: 1px solid #d4b8ea;
+  margin-left: 0.4rem;
+}
+
 /* === Toolbar === */
 .admin-toolbar {
   display: flex;
@@ -364,6 +371,26 @@
 .admin-content .form-group textarea {
   resize: vertical;
   min-height: 120px;
+}
+
+.admin-content .form-group .checkbox-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.admin-content .form-group .checkbox-label input[type="checkbox"] {
+  width: auto;
+  min-height: auto;
+  margin: 0;
+}
+
+.admin-content .form-group .form-hint {
+  font-size: 0.8rem;
+  color: #6c757d;
+  margin-top: 0.25rem;
 }
 
 .admin-content .form-group input:focus,

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -248,7 +248,8 @@ router.post('/members', async (req, res) => {
       await memberRepo.create({
         member_number, first_name, last_name, email, phone,
         address_street, address_city, address_state, address_zip,
-        membership_year: year, join_date: normalizedJoinDate, status: status || 'pending', notes,
+        membership_year: year, join_date: normalizedJoinDate, status: status || 'pending',
+        is_lifetime: req.body.is_lifetime === 'on', notes,
       });
 
       req.session.flash_success = `Member ${first_name} ${last_name} created.`;
@@ -331,7 +332,8 @@ router.post('/members/:id', async (req, res) => {
     await memberRepo.update(req.params.id, {
       first_name, last_name, email, phone,
       address_street, address_city, address_state, address_zip,
-      membership_year, join_date: normalizedJoinDate, status, notes,
+      membership_year, join_date: normalizedJoinDate, status,
+      is_lifetime: req.body.is_lifetime === 'on', notes,
     });
     req.session.flash_success = 'Member updated.';
   } catch (e) {
@@ -785,7 +787,13 @@ async function processCardTemplate(file, filename) {
         '-dNOPAUSE', '-dBATCH', '-sDEVICE=png16m', '-r300',
         `-sOutputFile=${tmpPng}`, tmpInput,
       ]);
-      await execFileAsync('magick', [tmpPng, '-trim', '-bordercolor', 'white', '-border', '20', outPath]);
+      // ImageMagick 7 uses `magick`; IM6 (common on Ubuntu LTS) uses `convert`
+      try {
+        await execFileAsync('magick', [tmpPng, '-trim', '-bordercolor', 'white', '-border', '20', outPath]);
+      } catch (e) {
+        if (e.code !== 'ENOENT') throw e;
+        await execFileAsync('convert', [tmpPng, '-trim', '-bordercolor', 'white', '-border', '20', outPath]);
+      }
       fs.unlinkSync(tmpPng);
     } else {
       fs.copyFileSync(tmpInput, outPath);

--- a/routes/index.js
+++ b/routes/index.js
@@ -64,6 +64,10 @@ router.post('/membership', requireCaptcha('/membership'), async (req, res) => {
         req.session.flash_error = 'That email is associated with a family membership. Please contact us for help.';
         return res.redirect('/membership');
       }
+      if (existing.is_lifetime) {
+        req.session.flash_success = 'You have a lifetime membership — no renewal needed!';
+        return res.redirect('/membership');
+      }
       if (existing.status === 'cancelled') {
         req.session.flash_error = 'Your membership has been cancelled. Please contact us to reinstate it.';
         return res.redirect('/membership');

--- a/user_guide/08-troubleshooting.md
+++ b/user_guide/08-troubleshooting.md
@@ -55,10 +55,10 @@
 
 **Problem:** Uploading a PDF card template produces an error or the template does not appear.
 
-- PDF-to-PNG conversion requires **Ghostscript** (`gs`) and **ImageMagick** (`magick`). Verify they are installed:
+- PDF-to-PNG conversion requires **Ghostscript** (`gs`) and **ImageMagick**. Verify they are installed:
   ```
   gs --version
-  magick --version
+  magick --version || convert --version
   ```
 - If either tool is missing, install it:
   ```
@@ -67,6 +67,7 @@
   # ImageMagick
   sudo apt-get install imagemagick
   ```
+- ImageMagick 7 uses `magick`; ImageMagick 6 (default on Ubuntu LTS / Render) uses `convert`. The app tries both automatically.
 - Check that the `data/` directory is writable; the conversion uses a temporary file there.
 
 ## Images Not Uploading

--- a/views/admin/members/form.pug
+++ b/views/admin/members/form.pug
@@ -59,7 +59,7 @@ block content
           option(value="cancelled" selected=(member && member.status === 'cancelled')) Cancelled
       .form-group
         label.checkbox-label
-          input(type="checkbox" name="is_lifetime" checked=(member && member.is_lifetime))
+          input(type="checkbox" name="is_lifetime" checked=(member && member.is_lifetime === 1))
           |  Lifetime Member
         p.form-hint Lifetime members are never included in renewal reminders.
     .form-group

--- a/views/admin/members/form.pug
+++ b/views/admin/members/form.pug
@@ -57,6 +57,11 @@ block content
           option(value="active" selected=(member && member.status === 'active')) Active
           option(value="expired" selected=(member && member.status === 'expired')) Expired
           option(value="cancelled" selected=(member && member.status === 'cancelled')) Cancelled
+      .form-group
+        label.checkbox-label
+          input(type="checkbox" name="is_lifetime" checked=(member && member.is_lifetime))
+          |  Lifetime Member
+        p.form-hint Lifetime members are never included in renewal reminders.
     .form-group
       label(for="notes") Notes
       textarea#notes(name="notes" rows="3")= member ? member.notes : ''

--- a/views/admin/members/list.pug
+++ b/views/admin/members/list.pug
@@ -31,6 +31,9 @@ block content
             td= m.membership_type === 'family' ? 'Family' : 'Individual'
             td
               span(class=`badge badge-${m.status}`)= m.status
+              if m.is_lifetime
+                |
+                span.badge.badge-lifetime Lifetime
             td= m.membership_year
             td
               a.btn-sm(href=`/admin/members/${m.id}`) Edit

--- a/views/admin/members/view.pug
+++ b/views/admin/members/view.pug
@@ -33,6 +33,9 @@ block content
           th Status
           td
             span(class=`badge badge-${member.status}`)= member.status
+            if member.is_lifetime
+              |
+              span.badge.badge-lifetime Lifetime
         if member.membership_type
           tr
             th Membership Type


### PR DESCRIPTION
- is_lifetime flag on members: schema, migration (PG + SQLite), admin form checkbox, purple badge on list/view, excluded from findNeedingRenewal
- /membership smart renewal: lifetime members get friendly flash, not a renewal email
- findByEmail now orders by primary_member_id IS NULL DESC so family primaries are returned before sub-members sharing the same email (fixes false "associated with a family membership" error for primary members)
- processCardTemplate: fall back from magick to convert for ImageMagick 6 compatibility on Ubuntu LTS / Render
- .gitignore: add .DS_Store
- docs: update troubleshooting guide for ImageMagick version note