### PR TITLE
add Renew Membership tab to membership page

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -660,6 +660,37 @@ footer {
   text-align: left;
 }
 
+/* Membership tab switcher */
+.membership-tabs {
+  display: flex;
+  gap: 0;
+  margin-bottom: 1.75rem;
+  border-bottom: 2px solid #e0e0e0;
+}
+
+.membership-tab {
+  background: none;
+  border: none;
+  border-bottom: 3px solid transparent;
+  margin-bottom: -2px;
+  padding: 0.6rem 1.1rem 0.7rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #888;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  white-space: nowrap;
+}
+
+.membership-tab:hover {
+  color: #002a5c;
+}
+
+.membership-tab-active {
+  color: #002a5c;
+  border-bottom-color: #002a5c;
+}
+
 /* Form section heading */
 .form-section-heading {
   font-size: 0.72rem;

--- a/public/js/membership.js
+++ b/public/js/membership.js
@@ -1,16 +1,44 @@
 (function () {
+  // ── Tab switching ──────────────────────────────────────────────────────────
+  const tabBtns = document.querySelectorAll('.membership-tab');
+  const tabNew = document.getElementById('tab-new');
+  const tabRenew = document.getElementById('tab-renew');
+
+  function switchTab(name) {
+    tabBtns.forEach(b => b.classList.toggle('membership-tab-active', b.dataset.tab === name));
+    if (tabNew) tabNew.style.display = name === 'new' ? 'block' : 'none';
+    if (tabRenew) tabRenew.style.display = name === 'renew' ? 'block' : 'none';
+
+    if (name === 'renew') {
+      const captchaStep = document.getElementById('renewal-captcha-step');
+      const emailSection = document.getElementById('renewal-email-section');
+      const hasCaptcha = captchaStep && captchaStep.querySelector('.h-captcha');
+      if (captchaStep && captchaStep.style.display === 'none') {
+        if (hasCaptcha) {
+          reveal(captchaStep);
+        } else {
+          if (emailSection) reveal(emailSection);
+        }
+      }
+    }
+  }
+
+  tabBtns.forEach(btn => {
+    btn.addEventListener('click', () => switchTab(btn.dataset.tab));
+  });
+
+  // ── Shared reveal helper ───────────────────────────────────────────────────
+  function reveal(el) {
+    el.style.display = 'block';
+    requestAnimationFrame(() => requestAnimationFrame(() => el.classList.add('membership-reveal')));
+  }
+
+  // ── New Member tab — card picker ──────────────────────────────────────────
   const typeCards = document.querySelectorAll('.membership-type-card');
   const captchaStep = document.getElementById('membership-captcha-step');
   const piiSection = document.getElementById('membership-pii-section');
   const hasCaptcha = captchaStep && captchaStep.querySelector('.h-captcha');
 
-  function reveal(el) {
-    el.style.display = 'block';
-    // Double rAF ensures the browser has painted display:block before animating
-    requestAnimationFrame(() => requestAnimationFrame(() => el.classList.add('membership-reveal')));
-  }
-
-  // Card picker — Step 1 → Step 2 (or Step 3 in dev)
   typeCards.forEach(card => {
     card.addEventListener('click', () => {
       typeCards.forEach(c => c.classList.remove('selected'));
@@ -21,25 +49,30 @@
         radio.dispatchEvent(new Event('change'));
       }
 
-      // Only trigger reveal on the first card pick
       if (captchaStep && captchaStep.style.display === 'none') {
         if (hasCaptcha) {
           reveal(captchaStep);
         } else {
-          // Dev: no captcha configured — reveal PII immediately
           if (piiSection) reveal(piiSection);
         }
       }
     });
   });
 
-  // hCaptcha callback — Step 2 → Step 3
+  // hCaptcha callbacks
   window.onMembershipCaptchaComplete = function () {
     if (captchaStep) captchaStep.style.display = 'none';
     if (piiSection) reveal(piiSection);
   };
 
-  // Family members section (lives inside PII, toggled by card type)
+  window.onRenewalCaptchaComplete = function () {
+    const renewalCaptchaStep = document.getElementById('renewal-captcha-step');
+    const renewalEmailSection = document.getElementById('renewal-email-section');
+    if (renewalCaptchaStep) renewalCaptchaStep.style.display = 'none';
+    if (renewalEmailSection) reveal(renewalEmailSection);
+  };
+
+  // ── Family members section ─────────────────────────────────────────────────
   const familySection = document.getElementById('family-members-section');
   if (!familySection) return;
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -165,6 +165,54 @@ router.get('/charitable/battle-of-the-birds', (_req, res) => res.render('charita
 router.get('/charitable/nonprofits', (_req, res) => res.render('charitable/nonprofits'));
 router.get('/charitable/heartwheels', (_req, res) => res.render('charitable/heartwheels'));
 
+// Renewal request — self-service from the Renew tab
+router.post('/membership/renew-request', requireCaptcha('/membership'), async (req, res) => {
+  const { email } = req.body;
+  if (!email) {
+    req.session.flash_error = 'Email address is required.';
+    return res.redirect('/membership');
+  }
+  try {
+    const existing = await memberRepo.findByEmail(email);
+    if (!existing) {
+      req.session.flash_success = `If that email is in our system, a renewal link has been sent.`;
+      return res.redirect('/membership');
+    }
+    if (existing.primary_member_id != null) {
+      req.session.flash_error = 'That email is associated with a family membership. Please contact us for help.';
+      return res.redirect('/membership');
+    }
+    if (existing.is_lifetime) {
+      req.session.flash_success = 'You have a lifetime membership — no renewal needed!';
+      return res.redirect('/membership');
+    }
+    if (existing.status === 'cancelled') {
+      req.session.flash_error = 'Your membership has been cancelled. Please contact us to reinstate it.';
+      return res.redirect('/membership');
+    }
+    const currentPeriod = await periodsRepo.getCurrent();
+    if (currentPeriod) {
+      const membershipYearsRepo = require('../db/repos/membershipYears');
+      const enrolled = await membershipYearsRepo.isEnrolled(existing.id, currentPeriod.id);
+      if (enrolled) {
+        req.session.flash_success = `You're already a member for this season! Check your email for your membership card.`;
+        return res.redirect('/membership');
+      }
+    }
+    const renewalService = require('../services/renewal');
+    const emailService = require('../services/email');
+    const token = await renewalService.generateRenewalToken(existing.id);
+    const baseUrl = process.env.BASE_URL || `http://localhost:${process.env.PORT || 3000}`;
+    const renewalLink = `${baseUrl}/renew/${token}`;
+    await emailService.sendRenewalReminderEmail(existing, renewalLink);
+    req.session.flash_success = `A renewal link has been sent to ${existing.email}.`;
+    return res.redirect('/membership');
+  } catch (e) {
+    req.session.flash_error = e.message;
+    return res.redirect('/membership');
+  }
+});
+
 // Membership success / cancel
 router.get('/membership/success', (req, res) => {
   res.render('membership-success');

--- a/views/membership.pug
+++ b/views/membership.pug
@@ -35,84 +35,107 @@ block content
               p "Montana's proudest and most dedicated Seahawks fan club — a non-profit supporting the Seahawks and the NFL."
 
           .membership-form-panel
-            h2 Become a Member
+            .membership-tabs
+              button.membership-tab.membership-tab-active(type="button" data-tab="new") Become a Member
+              button.membership-tab(type="button" data-tab="renew") Renew Membership
 
-            form.membership-form(method="POST" action="/membership")
-              input(type="hidden" name="_csrf" value=(typeof csrfToken !== 'undefined' ? csrfToken : ''))
+            //- ── Tab: New Member ──────────────────────────────────────
+            #tab-new
+              form.membership-form(method="POST" action="/membership")
+                input(type="hidden" name="_csrf" value=(typeof csrfToken !== 'undefined' ? csrfToken : ''))
 
-              //- Step 1: Membership Type (always visible)
-              p.form-section-heading Choose your plan
-              - const indTotal = individualDues + surchargeCents
-              - const famTotal = familyDues + surchargeCents
-              .membership-type-cards
-                label.membership-type-card
-                  input(type="radio" name="membership_type" value="individual")
-                  .card-check
-                  .card-type-name Individual
-                  .card-type-price $#{(indTotal / 100).toFixed(2)}
-                  .card-type-detail
-                    | $#{(individualDues / 100).toFixed(2)} dues
-                    if surchargeCents > 0
-                      |  + $#{(surchargeCents / 100).toFixed(2)} fee
-                label.membership-type-card
-                  input(type="radio" name="membership_type" value="family")
-                  .card-check
-                  .card-type-name Family
-                  .card-type-price $#{(famTotal / 100).toFixed(2)}
-                  .card-type-detail
-                    | $#{(familyDues / 100).toFixed(2)} dues · up to #{maxFamilyMembers} members
-                    if surchargeCents > 0
-                      |  + $#{(surchargeCents / 100).toFixed(2)} fee
+                //- Step 1: Membership Type (always visible)
+                p.form-section-heading Choose your plan
+                - const indTotal = individualDues + surchargeCents
+                - const famTotal = familyDues + surchargeCents
+                .membership-type-cards
+                  label.membership-type-card
+                    input(type="radio" name="membership_type" value="individual")
+                    .card-check
+                    .card-type-name Individual
+                    .card-type-price $#{(indTotal / 100).toFixed(2)}
+                    .card-type-detail
+                      | $#{(individualDues / 100).toFixed(2)} dues
+                      if surchargeCents > 0
+                        |  + $#{(surchargeCents / 100).toFixed(2)} fee
+                  label.membership-type-card
+                    input(type="radio" name="membership_type" value="family")
+                    .card-check
+                    .card-type-name Family
+                    .card-type-price $#{(famTotal / 100).toFixed(2)}
+                    .card-type-detail
+                      | $#{(familyDues / 100).toFixed(2)} dues · up to #{maxFamilyMembers} members
+                      if surchargeCents > 0
+                        |  + $#{(surchargeCents / 100).toFixed(2)} fee
 
-              //- Step 2: Captcha (revealed after a card is selected)
-              #membership-captcha-step(style="display: none;")
-                if hcaptchaSiteKey
-                  p.form-section-heading(style="margin-top: 1.5rem;") Verify you're human
-                  .h-captcha(data-sitekey=hcaptchaSiteKey data-callback="onMembershipCaptchaComplete")
+                //- Step 2: Captcha (revealed after a card is selected)
+                #membership-captcha-step(style="display: none;")
+                  if hcaptchaSiteKey
+                    p.form-section-heading(style="margin-top: 1.5rem;") Verify you're human
+                    .h-captcha(data-sitekey=hcaptchaSiteKey data-callback="onMembershipCaptchaComplete")
 
-              //- Step 3: PII (revealed after captcha is completed, or immediately in dev)
-              #membership-pii-section(style="display: none;")
-                p.form-section-heading Your information
-                .form-grid-2
+                //- Step 3: PII (revealed after captcha, or immediately in dev)
+                #membership-pii-section(style="display: none;")
+                  p.form-section-heading Your information
+                  .form-grid-2
+                    .form-group
+                      label(for="first_name") First Name
+                      input#first_name(type="text" name="first_name" required)
+                    .form-group
+                      label(for="last_name") Last Name
+                      input#last_name(type="text" name="last_name" required)
                   .form-group
-                    label(for="first_name") First Name
-                    input#first_name(type="text" name="first_name" required)
+                    label(for="email") Email
+                    input#email(type="email" name="email" required)
                   .form-group
-                    label(for="last_name") Last Name
-                    input#last_name(type="text" name="last_name" required)
-                .form-group
-                  label(for="email") Email
-                  input#email(type="email" name="email" required)
-                .form-group
-                  label(for="phone")
-                    | Phone&nbsp;
+                    label(for="phone")
+                      | Phone&nbsp;
+                      span.label-optional (optional)
+                    input#phone(type="tel" name="phone")
+
+                  p.form-section-heading
+                    | Mailing address&nbsp;
                     span.label-optional (optional)
-                  input#phone(type="tel" name="phone")
-
-                p.form-section-heading
-                  | Mailing address&nbsp;
-                  span.label-optional (optional)
-                .form-group
-                  label(for="address_street") Street Address
-                  input#address_street(type="text" name="address_street")
-                .form-grid-2
                   .form-group
-                    label(for="address_city") City
-                    input#address_city(type="text" name="address_city")
+                    label(for="address_street") Street Address
+                    input#address_street(type="text" name="address_street")
+                  .form-grid-2
+                    .form-group
+                      label(for="address_city") City
+                      input#address_city(type="text" name="address_city")
+                    .form-group
+                      label(for="address_state") State
+                      input#address_state(type="text" name="address_state" value="MT")
                   .form-group
-                    label(for="address_state") State
-                    input#address_state(type="text" name="address_state" value="MT")
-                .form-group
-                  label(for="address_zip") ZIP Code
-                  input#address_zip(type="text" name="address_zip")
+                    label(for="address_zip") ZIP Code
+                    input#address_zip(type="text" name="address_zip")
 
-                //- Family Members Section (shown by JS when Family card is selected)
-                #family-members-section(data-max=maxFamilyMembers style="display: none; margin-top: 1.5rem;")
-                  p.form-section-heading Additional Family Members
-                  p.text-muted(style="margin-bottom: 1rem; font-size: 0.9rem; color: #555;") You may add up to #{maxFamilyMembers - 1} additional family members. Each will receive their own membership card.
-                  #family-members-container
-                  button.btn-outline(type="button" id="add-family-member") + Add Family Member
+                  //- Family Members Section (shown by JS when Family card is selected)
+                  #family-members-section(data-max=maxFamilyMembers style="display: none; margin-top: 1.5rem;")
+                    p.form-section-heading Additional Family Members
+                    p.text-muted(style="margin-bottom: 1rem; font-size: 0.9rem; color: #555;") You may add up to #{maxFamilyMembers - 1} additional family members. Each will receive their own membership card.
+                    #family-members-container
+                    button.btn-outline(type="button" id="add-family-member") + Add Family Member
 
-                button.btn.btn-full(type="submit") Continue to Payment →
+                  button.btn.btn-full(type="submit") Continue to Payment →
+
+            //- ── Tab: Renew Membership ────────────────────────────────
+            #tab-renew(style="display: none;")
+              //- Step 1: Captcha (revealed when tab is clicked)
+              #renewal-captcha-step(style="display: none;")
+                if hcaptchaSiteKey
+                  p.form-section-heading(style="margin-top: 0.5rem;") Verify you're human
+                  .h-captcha(data-sitekey=hcaptchaSiteKey data-callback="onRenewalCaptchaComplete")
+
+              //- Step 2: Email form (revealed after captcha, or immediately in dev)
+              #renewal-email-section(style="display: none;")
+                form(method="POST" action="/membership/renew-request")
+                  input(type="hidden" name="_csrf" value=(typeof csrfToken !== 'undefined' ? csrfToken : ''))
+                  p.form-section-heading(style="margin-top: 0.5rem;") Enter your email address
+                  p(style="font-size: 0.9rem; color: #555; margin-bottom: 1.25rem;") We'll send a renewal link to the email address on your account.
+                  .form-group
+                    label(for="renew_email") Email Address
+                    input#renew_email(type="email" name="email" required autocomplete="email")
+                  button.btn.btn-full(type="submit") Send Renewal Link →
 
   script(src="/js/membership.js")


### PR DESCRIPTION
- Two-tab layout on membership form panel: "Become a Member" and "Renew Membership" with underline-style tab switcher
- Renew tab: captcha animates in on tab click, email form reveals after captcha completes (dev mode skips captcha)
- POST /membership/renew-request: generates and emails renewal token; handles cancelled, lifetime, already-enrolled, family sub-member, and unknown email cases (unknown returns vague success to avoid enumeration)
