### PR TITLE
right-align Continue to Payment button in renew form

### DIFF
--- a/views/renew.pug
+++ b/views/renew.pug
@@ -73,6 +73,7 @@ block content
 
           button.btn-outline(type="button" id="add-family-member" style=(familyMembers.length >= maxFamilyMembers - 1 ? 'display:none' : '')) + Add Family Member
 
-        button.btn(type="submit" style="margin-top: 2rem;") Continue to Payment →
+        div(style="margin-top: 2rem; text-align: right;")
+          button.btn(type="submit") Continue to Payment →
 
   script(src="/js/renew.js")


### PR DESCRIPTION
This pull request makes a small UI improvement to the `views/renew.pug` file. The "Continue to Payment" button is now right-aligned and visually separated from other content for better layout and user experience.

- UI improvement:
  * The "Continue to Payment" button is wrapped in a right-aligned `div` with top margin, replacing the previous inline style on the button. (`views/renew.pug`)## Summary