### PR TITLE
Fix renewal delivering last year's membership card (#67)

### DIFF
--- a/db/repos/cards.js
+++ b/db/repos/cards.js
@@ -17,12 +17,12 @@ async function findByMemberId(memberId) {
 async function findByMemberAndYear(memberId, year) {
     if (year == null) {
         return await db.get(
-            'SELECT id FROM membership_cards WHERE member_id = ? AND year IS NULL',
+            'SELECT * FROM membership_cards WHERE member_id = ? AND year IS NULL',
             memberId
         );
     }
     return await db.get(
-    'SELECT id FROM membership_cards WHERE member_id = ? AND year = ?',
+    'SELECT * FROM membership_cards WHERE member_id = ? AND year = ?',
     memberId, year
   );
 }
@@ -54,6 +54,7 @@ async function upsertPdf(memberId, year, pdfPath) {
 module.exports = {
   findLatestByMemberId,
   findByMemberId,
+  findByMemberAndYear,
   upsertPng,
   upsertPdf,
 };

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -375,7 +375,8 @@ router.get('/members/:id/card/pdf', async (req, res) => {
     req.session.flash_error = 'Member not found.';
     return res.redirect('/admin/members');
   }
-  const card = await cardsRepo.findLatestByMemberId(req.params.id);
+  const card = await cardsRepo.findByMemberAndYear(member.id, member.membership_year)
+    || await cardsRepo.findLatestByMemberId(req.params.id);
   if (!card || !card.pdf_path) { req.session.flash_error = 'No card found.'; return res.redirect(`/admin/members/${req.params.id}`); }
   const filename = `YSH-${member.first_name}-${member.last_name}-${card.year || 'card'}.pdf`;
   if (card.pdf_path.startsWith('http')) {
@@ -404,7 +405,8 @@ router.get('/members/:id/card/png', async (req, res) => {
     req.session.flash_error = 'Member not found.';
     return res.redirect('/admin/members');
   }
-  const card = await cardsRepo.findLatestByMemberId(req.params.id);
+  const card = await cardsRepo.findByMemberAndYear(member.id, member.membership_year)
+    || await cardsRepo.findLatestByMemberId(req.params.id);
   if (!card || !card.png_path) { req.session.flash_error = 'No card found.'; return res.redirect(`/admin/members/${req.params.id}`); }
   const filename = `YSH-${member.first_name}-${member.last_name}-${card.year || 'card'}.png`;
   if (card.png_path.startsWith('http')) {

--- a/routes/stripe.js
+++ b/routes/stripe.js
@@ -72,13 +72,16 @@ router.post('/webhook', async (req, res) => {
         familyMembers.map(async fm => (await findMemberById(fm.id)) || fm)
       );
 
-      // 5. Generate cards for all members
+      // 5. Generate cards for all members. Track which members got a card so we
+      //    never email a stale prior-year card when generation fails (issue #67).
       const allMembers = [refreshedPrimary, ...refreshedFamily];
+      const cardGenerated = new Set();
       for (const member of allMembers) {
         try {
           const { generatePDF, generatePNG } = require('../services/card');
           await generatePDF(member);
           await generatePNG(member);
+          cardGenerated.add(member.id);
         } catch (e) {
           logger.error('Card generation error', {
             memberNumber: member.member_number,
@@ -96,8 +99,15 @@ router.post('/webhook', async (req, res) => {
         await emailService.sendWelcomeEmail(refreshedPrimary);
         await emailService.sendPaymentConfirmation(refreshedPrimary, session);
 
-        // All members: card email
+        // Card email — only for members whose current-year card was produced.
         for (const member of allMembers) {
+          if (!cardGenerated.has(member.id)) {
+            logger.warn('Skipping card email — no card generated', {
+              memberNumber: member.member_number,
+              membershipYear: member.membership_year,
+            });
+            continue;
+          }
           await emailService.sendCardEmail(member);
         }
       } catch (e) {

--- a/services/card.js
+++ b/services/card.js
@@ -46,7 +46,13 @@ async function resolveTemplate(memberId) {
     memberId
   );
   if (row?.card_template_path) {
-    return path.join(CARD_TEMPLATE_DIR, row.card_template_path);
+    const templatePath = path.join(CARD_TEMPLATE_DIR, row.card_template_path);
+    // Fall back to the default template if the period's configured template
+    // file is missing — otherwise card generation throws and the renewal
+    // silently ships no card (issue #67).
+    if (fs.existsSync(templatePath)) {
+      return templatePath;
+    }
   }
   return TEMPLATE_PNG;
 }

--- a/services/email.js
+++ b/services/email.js
@@ -190,9 +190,14 @@ async function getCardBuffer(cardPath) {
 }
 
 async function sendCardEmail(member) {
-  const card = await cardsRepo.findLatestByMemberId(member.id);
+  // Look up the card for the member's CURRENT membership year — never fall back
+  // to an older card, or a renewal whose new-year card failed to generate would
+  // silently ship last season's card (see issue #67).
+  const card = await cardsRepo.findByMemberAndYear(member.id, member.membership_year);
 
-  if (!card) throw new Error('No card found for this member');
+  if (!card) {
+    throw new Error(`No ${member.membership_year} card found for member ${member.id}`);
+  }
 
   const attachments = [];
   if (card.pdf_path) {

--- a/test/routes/renewal-card-generation-failure.test.js
+++ b/test/routes/renewal-card-generation-failure.test.js
@@ -1,0 +1,132 @@
+// Regression: renewal delivers last year's membership card.
+//
+// Reported symptom: after renewing, the member's new membership_year is set
+// correctly, but they receive LAST YEAR's card. Root cause (Defect A): the
+// Stripe webhook wraps card generation in a try/catch that logs and swallows
+// any error (routes/stripe.js). When generation throws, no current-year card
+// row is written, yet the webhook still fires sendCardEmail — which then
+// attaches the stale prior-year card.
+//
+// These tests exercise the webhook with card generation FORCED TO THROW and
+// assert the fix target:
+//   1. the failure is swallowed today (webhook still 200s) — documents the trap
+//   2. no current-year membership_cards row is created (the observed symptom)
+//   3. after the fix, no card email should be sent when the current-year card
+//      was not produced (so a stale card can never be delivered as current)
+
+jest.mock('../../db/database', () => require('../helpers/setupDb'));
+
+const db = require('../../db/database');
+const { insertMember, insertPeriod, insertCard } = require('../helpers/fixtures');
+
+const mockHandlers = {};
+jest.mock('express', () => {
+  const realExpress = jest.requireActual('express');
+  const fakeRouter = {
+    get(path, ...fns) { mockHandlers['GET ' + path] = fns[fns.length - 1]; },
+    post(path, ...fns) { mockHandlers['POST ' + path] = fns[fns.length - 1]; },
+    use() {},
+  };
+  return { ...realExpress, Router: () => fakeRouter };
+});
+
+jest.mock('../../services/stripe', () => ({
+  constructWebhookEvent: jest.fn(),
+}));
+
+// Card generation FAILS — mimics a real production failure (missing template
+// file, storage upload error, canvas/font error, etc.).
+jest.mock('../../services/card', () => ({
+  generatePDF: jest.fn().mockRejectedValue(new Error('template not found')),
+  generatePNG: jest.fn().mockRejectedValue(new Error('template not found')),
+}));
+
+jest.mock('../../services/email', () => ({
+  sendWelcomeEmail: jest.fn().mockResolvedValue(undefined),
+  sendPaymentConfirmation: jest.fn().mockResolvedValue(undefined),
+  sendCardEmail: jest.fn().mockResolvedValue(undefined),
+}));
+
+const stripeService = require('../../services/stripe');
+const emailService = require('../../services/email');
+
+function mockReq(overrides = {}) {
+  return { headers: { 'stripe-signature': 'sig' }, body: Buffer.from('{}'), ...overrides };
+}
+function mockRes() {
+  return { json: jest.fn() };
+}
+function checkoutCompletedEvent(session) {
+  return { type: 'checkout.session.completed', data: { object: session } };
+}
+
+beforeEach(() => {
+  db.__resetTestDb();
+  Object.keys(mockHandlers).forEach(k => delete mockHandlers[k]);
+  jest.clearAllMocks();
+  jest.isolateModules(() => { require('../../routes/stripe'); });
+});
+
+function getTestDb() {
+  return db.__getCurrentDb();
+}
+
+describe('renewal when card generation fails', () => {
+  async function renew() {
+    const testDb = getTestDb();
+    // Renewing member who already holds LAST season's card (2025).
+    const member = insertMember(testDb, {
+      email: 'renewer@test.com',
+      status: 'pending',
+      membership_year: 2025,
+    });
+    insertCard(testDb, {
+      member_id: member.id,
+      pdf_path: 'https://b2.example.com/cards/card-1-2025.pdf',
+      png_path: 'https://b2.example.com/cards/card-1-2025.png',
+      year: 2025,
+    });
+    // New season period (start year 2026).
+    const period = insertPeriod(testDb, {
+      label: '2026-27 Season',
+      start_date: '2026-04-01',
+      end_date: '2027-07-31',
+    });
+
+    stripeService.constructWebhookEvent.mockReturnValue(
+      checkoutCompletedEvent({
+        id: 'cs_test_123',
+        payment_intent: 'pi_test_123',
+        amount_total: 1600,
+        metadata: { member_id: String(member.id), period_id: String(period.id) },
+      })
+    );
+
+    const res = mockRes();
+    await mockHandlers['POST /webhook'](mockReq(), res);
+    return { member, res, testDb };
+  }
+
+  test('the year advances but no current-year (2026) card row is created', async () => {
+    const { member, res, testDb } = await renew();
+
+    // Webhook still succeeds — the generation error was swallowed.
+    expect(res.json).toHaveBeenCalledWith({ received: true });
+    // Year advanced as reported.
+    const updated = testDb.prepare('SELECT membership_year FROM members WHERE id = ?').get(member.id);
+    expect(updated.membership_year).toBe(2026);
+
+    // The observed symptom: no 2026 card exists — only last year's remains.
+    const card2026 = testDb.prepare(
+      'SELECT * FROM membership_cards WHERE member_id = ? AND year = 2026'
+    ).get(member.id);
+    expect(card2026).toBeUndefined();
+  });
+
+  test('no card email is sent when the current-year card was not generated', async () => {
+    // Fix target: the webhook must not deliver a card email (which would attach
+    // the stale 2025 card) when the 2026 card failed to generate.
+    await renew();
+    expect(emailService.sendCardEmail).not.toHaveBeenCalled();
+  });
+});

--- a/test/services/card-email-current-year.test.js
+++ b/test/services/card-email-current-year.test.js
@@ -1,0 +1,93 @@
+// Regression: sendCardEmail must attach the member's CURRENT-year card, never
+// whichever card was created most recently.
+//
+// Root cause (Defect B): sendCardEmail (services/email.js) looks up the card
+// via cardsRepo.findLatestByMemberId(), which is `ORDER BY created_at DESC
+// LIMIT 1` and ignores the `year` column. When the current-year card is
+// missing (e.g. renewal generation failed — see Defect A), this returns last
+// year's card and emails it as if it were the current season's.
+//
+// The attachment is even mislabeled: the filename is built from
+// member.membership_year (2026) while the bytes fetched are the 2025 card.
+
+jest.mock('../../db/database', () => require('../helpers/setupDb'));
+
+const db = require('../../db/database');
+const { insertMember, insertCard } = require('../helpers/fixtures');
+
+let emailService;
+let member;
+
+beforeEach(() => {
+  db.__resetTestDb();
+  jest.clearAllMocks();
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 202 });
+
+  jest.isolateModules(() => {
+    emailService = require('../../services/email');
+  });
+
+  const testDb = db.__getCurrentDb();
+  // Member has renewed into the 2026 season...
+  member = insertMember(testDb, {
+    email: 'member@test.com',
+    first_name: 'John',
+    last_name: 'Doe',
+    membership_year: 2026,
+    status: 'active',
+  });
+  // ...but only LAST year's card (2025) exists — the 2026 card never generated.
+  insertCard(testDb, {
+    member_id: member.id,
+    pdf_path: 'https://b2.example.com/cards/card-1-2025.pdf',
+    png_path: 'https://b2.example.com/cards/card-1-2025.png',
+    year: 2025,
+  });
+});
+
+describe('sendCardEmail — current-year selection', () => {
+  test('does not deliver last year\'s card when the current-year card is missing', async () => {
+    // Track which card files get fetched for attachment.
+    global.fetch = jest.fn().mockImplementation((url) => {
+      if (typeof url === 'string' && url.startsWith('https://b2.example.com')) {
+        return Promise.resolve({ ok: true, arrayBuffer: () => Promise.resolve(Buffer.from('x').buffer) });
+      }
+      return Promise.resolve({ ok: true, status: 202 });
+    });
+
+    // Fix target: with no 2026 card, sendCardEmail must NOT silently attach the
+    // 2025 card. It should refuse (throw) rather than deliver a stale card.
+    await expect(emailService.sendCardEmail(member)).rejects.toThrow();
+
+    const staleFetches = global.fetch.mock.calls.filter(
+      ([url]) => typeof url === 'string' && url.includes('2025')
+    );
+    expect(staleFetches).toHaveLength(0);
+  });
+
+  test('attaches the current-year card when it exists', async () => {
+    const testDb = db.__getCurrentDb();
+    insertCard(testDb, {
+      member_id: member.id,
+      pdf_path: 'https://b2.example.com/cards/card-1-2026.pdf',
+      png_path: 'https://b2.example.com/cards/card-1-2026.png',
+      year: 2026,
+    });
+
+    global.fetch = jest.fn().mockImplementation((url) => {
+      if (typeof url === 'string' && url.startsWith('https://b2.example.com')) {
+        return Promise.resolve({ ok: true, arrayBuffer: () => Promise.resolve(Buffer.from('x').buffer) });
+      }
+      return Promise.resolve({ ok: true, status: 202 });
+    });
+
+    await emailService.sendCardEmail(member);
+
+    const fetched = global.fetch.mock.calls
+      .map(([url]) => url)
+      .filter((url) => typeof url === 'string' && url.startsWith('https://b2.example.com'));
+    // Only the 2026 card should be fetched — never the 2025 one.
+    expect(fetched.every((url) => url.includes('2026'))).toBe(true);
+    expect(fetched.some((url) => url.includes('2025'))).toBe(false);
+  });
+});

--- a/test/services/email.test.js
+++ b/test/services/email.test.js
@@ -100,8 +100,8 @@ describe('sendPaymentConfirmation', () => {
 });
 
 describe('sendCardEmail', () => {
-  test('throws when no card exists for member', async () => {
-    await expect(emailService.sendCardEmail(testMember)).rejects.toThrow('No card found');
+  test('throws when no card exists for the member\'s current year', async () => {
+    await expect(emailService.sendCardEmail(testMember)).rejects.toThrow(/No 2025 card found/);
   });
 
   test('sends email when card exists with pdf and png', async () => {


### PR DESCRIPTION
Closes #67 

Renewals advanced membership_year correctly but delivered the prior year's card. Two defects combined:

- routes/stripe.js swallowed card-generation errors, so a failed generatePDF/generatePNG left no current-year card while the renewal still "succeeded".
- services/email.js looked up cards via findLatestByMemberId (ORDER BY created_at DESC), ignoring the year column, and emailed last year's card as current.

Fixes:
- cards.js: findByMemberAndYear returns the full row and is exported
- email.js: sendCardEmail looks up by member.membership_year and refuses (throws) when the current-year card is missing
- stripe.js: only email a card for members whose card actually generated; log + skip otherwise
- card.js: resolveTemplate falls back to the default template when a period's card_template_path file is missing (a likely generation failure trigger) instead of throwing
- admin.js: card serve routes prefer the current-year card

Adds reproduction tests for both defects.