### PR TITLE
Add status and membership period filters to members table

### DIFF
--- a/db/repos/members.js
+++ b/db/repos/members.js
@@ -109,14 +109,32 @@ async function countByYear(year) {
   return row ? row.c : 0;
 }
 
-async function search({ search, limit, offset }) {
-  let where = '';
-  let params = [];
+async function search({ search, status, periodId, limit, offset }) {
+  const clauses = [];
+  const params = [];
+
   if (search) {
-    where = 'WHERE LOWER(first_name) LIKE ? OR LOWER(last_name) LIKE ? OR LOWER(email) LIKE ? OR LOWER(member_number) LIKE ?';
+    clauses.push('(LOWER(first_name) LIKE ? OR LOWER(last_name) LIKE ? OR LOWER(email) LIKE ? OR LOWER(member_number) LIKE ?)');
     const s = `%${search.toLowerCase()}%`;
-    params = [s, s, s, s];
+    params.push(s, s, s, s);
   }
+
+  if (status === 'active') {
+    clauses.push("status = 'active' AND (expiry_date IS NULL OR expiry_date >= date('now'))");
+  } else if (status === 'expired') {
+    clauses.push("status != 'cancelled' AND expiry_date IS NOT NULL AND expiry_date < date('now')");
+  } else if (status === 'cancelled') {
+    clauses.push("status = 'cancelled'");
+  } else if (status === 'pending') {
+    clauses.push("status = 'pending'");
+  }
+
+  if (periodId) {
+    clauses.push('id IN (SELECT member_id FROM membership_years WHERE membership_period_id = ?)');
+    params.push(periodId);
+  }
+
+  const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
   const totalRow = await db.get(`SELECT COUNT(*) as c FROM members ${where}`, ...params);
   const total = totalRow ? totalRow.c : 0;
   const members = await db.all(`SELECT * FROM members ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`, ...params, limit, offset);

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -159,11 +159,14 @@ router.get('/members', async (req, res, next) => {
     const limit = 25;
     const offset = (page - 1) * limit;
     const search = req.query.search || '';
+    const status = req.query.status || '';
+    const period = req.query.period ? parseInt(req.query.period) : '';
 
-    const { members, total } = await memberRepo.search({ search, limit, offset });
+    const { members, total } = await memberRepo.search({ search, status, periodId: period || undefined, limit, offset });
     const totalPages = Math.ceil(total / limit);
+    const periods = await periodsRepo.list();
 
-    res.render('admin/members/list', { members, page, totalPages, search, total });
+    res.render('admin/members/list', { members, page, totalPages, search, status, period, periods, total });
   } catch (err) {
     next(err);
   }

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -17,13 +17,13 @@ function buildMember(overrides = {}) {
 function insertMember(db, overrides = {}) {
   const m = buildMember(overrides);
   const info = db.prepare(
-    `INSERT INTO members (first_name, last_name, email, phone, address_street, address_city, address_state, address_zip, membership_year, status, member_number, membership_type, primary_member_id)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    `INSERT INTO members (first_name, last_name, email, phone, address_street, address_city, address_state, address_zip, membership_year, status, member_number, membership_type, primary_member_id, expiry_date)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(
     m.first_name, m.last_name, m.email, m.phone,
     m.address_street, m.address_city, m.address_state, m.address_zip,
     m.membership_year, m.status, m.member_number || null,
-    m.membership_type || 'individual', m.primary_member_id || null
+    m.membership_type || 'individual', m.primary_member_id || null, m.expiry_date || null
   );
   return { ...m, id: info.lastInsertRowid };
 }

--- a/test/repos/members.test.js
+++ b/test/repos/members.test.js
@@ -2,7 +2,11 @@ jest.mock('../../db/database', () => require('../helpers/setupDb'));
 
 const db = require('../../db/database');
 const memberRepo = require('../../db/repos/members');
-const { insertMember, insertAdmin, insertFamilyMembership } = require('../helpers/fixtures');
+const { insertMember, insertAdmin, insertFamilyMembership, insertPeriod, enrollMember } = require('../helpers/fixtures');
+
+// Dates relative to today for status-by-expiry tests.
+const FUTURE = '2999-01-01';
+const PAST = '2000-01-01';
 
 beforeEach(() => {
   db.__resetTestDb();
@@ -149,6 +153,73 @@ describe('search', () => {
     expect((await memberRepo.search({ search: 'alice@example.com', limit: 25, offset: 0 })).total).toBe(1);
     // Member number match ignoring case.
     expect((await memberRepo.search({ search: 'ysh-0042', limit: 25, offset: 0 })).total).toBe(1);
+  });
+
+  test('status=active excludes cancelled and past-expiry members', async () => {
+    const testDb = db.__getCurrentDb();
+    insertMember(testDb, { email: 'a@a.com', status: 'active', expiry_date: FUTURE });
+    insertMember(testDb, { email: 'b@b.com', status: 'active', expiry_date: null });
+    insertMember(testDb, { email: 'c@c.com', status: 'active', expiry_date: PAST });
+    insertMember(testDb, { email: 'd@d.com', status: 'cancelled', expiry_date: FUTURE });
+    insertMember(testDb, { email: 'e@e.com', status: 'pending' });
+
+    const result = await memberRepo.search({ status: 'active', limit: 25, offset: 0 });
+    expect(result.total).toBe(2);
+    expect(result.members.map((m) => m.email).sort()).toEqual(['a@a.com', 'b@b.com']);
+  });
+
+  test('status=expired returns only non-cancelled members past expiry', async () => {
+    const testDb = db.__getCurrentDb();
+    insertMember(testDb, { email: 'a@a.com', status: 'active', expiry_date: PAST });
+    insertMember(testDb, { email: 'b@b.com', status: 'expired', expiry_date: PAST });
+    insertMember(testDb, { email: 'c@c.com', status: 'active', expiry_date: FUTURE });
+    insertMember(testDb, { email: 'd@d.com', status: 'cancelled', expiry_date: PAST });
+    insertMember(testDb, { email: 'e@e.com', status: 'pending', expiry_date: null });
+
+    const result = await memberRepo.search({ status: 'expired', limit: 25, offset: 0 });
+    expect(result.total).toBe(2);
+    expect(result.members.map((m) => m.email).sort()).toEqual(['a@a.com', 'b@b.com']);
+  });
+
+  test('status=cancelled and status=pending filter on the stored status', async () => {
+    const testDb = db.__getCurrentDb();
+    insertMember(testDb, { email: 'a@a.com', status: 'cancelled' });
+    insertMember(testDb, { email: 'b@b.com', status: 'pending' });
+    insertMember(testDb, { email: 'c@c.com', status: 'active', expiry_date: FUTURE });
+
+    expect((await memberRepo.search({ status: 'cancelled', limit: 25, offset: 0 })).total).toBe(1);
+    expect((await memberRepo.search({ status: 'pending', limit: 25, offset: 0 })).total).toBe(1);
+  });
+
+  test('periodId returns only members enrolled in that period', async () => {
+    const testDb = db.__getCurrentDb();
+    const m1 = insertMember(testDb, { email: 'a@a.com' });
+    const m2 = insertMember(testDb, { email: 'b@b.com' });
+    insertMember(testDb, { email: 'c@c.com' });
+    const period = insertPeriod(testDb, { label: '2025-26' });
+    const other = insertPeriod(testDb, { label: '2024-25', start_date: '2024-04-01', end_date: '2025-03-31' });
+    enrollMember(testDb, m1.id, period.id);
+    enrollMember(testDb, m2.id, other.id);
+
+    const result = await memberRepo.search({ periodId: period.id, limit: 25, offset: 0 });
+    expect(result.total).toBe(1);
+    expect(result.members[0].email).toBe('a@a.com');
+  });
+
+  test('combines search, status and periodId with AND', async () => {
+    const testDb = db.__getCurrentDb();
+    const period = insertPeriod(testDb);
+    const match = insertMember(testDb, { email: 'alice@a.com', first_name: 'Alice', status: 'active', expiry_date: FUTURE });
+    // Same period + active but name does not match search.
+    const m2 = insertMember(testDb, { email: 'bob@b.com', first_name: 'Bob', status: 'active', expiry_date: FUTURE });
+    // Matches search + active but not enrolled in the period.
+    insertMember(testDb, { email: 'alice2@a.com', first_name: 'Alice', status: 'active', expiry_date: FUTURE });
+    enrollMember(testDb, match.id, period.id);
+    enrollMember(testDb, m2.id, period.id);
+
+    const result = await memberRepo.search({ search: 'alice', status: 'active', periodId: period.id, limit: 25, offset: 0 });
+    expect(result.total).toBe(1);
+    expect(result.members[0].email).toBe('alice@a.com');
   });
 });
 

--- a/views/admin/members/list.pug
+++ b/views/admin/members/list.pug
@@ -7,6 +7,16 @@ block content
   .admin-toolbar
     form.search-form(method="GET" action="/admin/members")
       input(type="text" name="search" placeholder="Search members..." value=search)
+      select(name="status" data-autosubmit)
+        option(value="" selected=(status === '')) All statuses
+        option(value="active" selected=(status === 'active')) Active
+        option(value="pending" selected=(status === 'pending')) Pending
+        option(value="expired" selected=(status === 'expired')) Expired
+        option(value="cancelled" selected=(status === 'cancelled')) Cancelled
+      select(name="period" data-autosubmit)
+        option(value="" selected=(!period)) All periods
+        each p in periods
+          option(value=p.id selected=(period === p.id))= p.label || `${p.start_date}–${p.end_date}`
       button.btn(type="submit") Search
     a.btn(href="/admin/members/new") + New Member
     a.btn-outline(href="/admin/members/export") Export CSV
@@ -41,9 +51,9 @@ block content
     if totalPages > 1
       .pagination
         if page > 1
-          a(href=`/admin/members?page=${page - 1}&search=${search}`) &laquo; Prev
+          a(href=`/admin/members?page=${page - 1}&search=${search}&status=${status}&period=${period}`) &laquo; Prev
         span Page #{page} of #{totalPages} (#{total} total)
         if page < totalPages
-          a(href=`/admin/members?page=${page + 1}&search=${search}`) Next &raquo;
+          a(href=`/admin/members?page=${page + 1}&search=${search}&status=${status}&period=${period}`) Next &raquo;
   else
     p.text-muted No members found.


### PR DESCRIPTION
Extend memberRepo.search() with optional status and periodId filters, wired into GET /admin/members via two auto-submitting dropdowns. Expired is derived from expiry_date (< today, not cancelled) since nothing sets status='expired' automatically. Pagination links preserve all filters.

Closes #66 
