### PR TITLE
Add plain-text alternative part to outgoing emails

### DIFF
--- a/services/email.js
+++ b/services/email.js
@@ -78,12 +78,35 @@ async function logEmail({ to_email, to_name, subject, body_html, email_type, sta
   }
 }
 
+function htmlToText(html) {
+  return String(html)
+    .replace(/<style[\s\S]*?<\/style>/gi, '')
+    .replace(/<a\s[^>]*href="([^"]*)"[^>]*>([\s\S]*?)<\/a>/gi, (_m, href, label) => {
+      const text = label.replace(/<[^>]+>/g, '').trim();
+      return text && text !== href ? `${text}: ${href}` : href;
+    })
+    .replace(/<\/(p|div|tr|h[1-6]|li)>/gi, '\n')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&#0?39;|&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/[ \t]+/g, ' ')
+    .replace(/\s*\n\s*/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
 async function mailersendSend({ to, toName, from, subject, html, attachments }) {
   const body = {
     from: { email: from.email, name: from.name },
     to: [{ email: to, name: toName || to }],
     subject,
     html,
+    text: htmlToText(html),
   };
   if (attachments && attachments.length > 0) {
     body.attachments = attachments.map(a => ({
@@ -326,4 +349,5 @@ module.exports = {
   sendOtpEmail,
   sendContactEmail,
   sendRenewalReminderEmail,
+  htmlToText,
 };

--- a/test/services/email.test.js
+++ b/test/services/email.test.js
@@ -272,3 +272,20 @@ describe('sendContactEmail', () => {
     expect(body.subject).toContain('Alice');
   });
 });
+
+describe('plain-text alternative part', () => {
+  test('every email includes a text part derived from the HTML', async () => {
+    await emailService.sendWelcomeEmail(testMember);
+    const body = getFetchBody();
+    expect(body.text).toBeDefined();
+    expect(body.text).toContain('YSH-2025-0001');
+    expect(body.text).not.toContain('<');
+  });
+
+  test('htmlToText strips tags and preserves link URLs', () => {
+    const text = emailService.htmlToText(
+      '<p>Hello &amp; welcome</p><p><a href="https://example.com/renew/abc">Renew My Membership</a></p>'
+    );
+    expect(text).toBe('Hello & welcome\nRenew My Membership: https://example.com/renew/abc');
+  });
+});


### PR DESCRIPTION
Derive a text/plain body from each email's HTML so MailerSend sends a multipart message. HTML-only mail is a common spam signal; including a text alternative improves deliverability. htmlToText strips markup, preserves link URLs, and decodes common entities.
