### PR TITLE
Add status and membership period filters to members table

### DIFF
--- a/db/repos/members.js
+++ b/db/repos/members.js
@@ -109,18 +109,134 @@ async function countByYear(year) {
   return row ? row.c : 0;
 }
 
-async function search({ search, limit, offset }) {
-  let where = '';
-  let params = [];
-  if (search) {
-    where = 'WHERE LOWER(first_name) LIKE ? OR LOWER(last_name) LIKE ? OR LOWER(email) LIKE ? OR LOWER(member_number) LIKE ?';
-    const s = `%${search.toLowerCase()}%`;
-    params = [s, s, s, s];
+// Dates are always computed in JS and bound as parameters: expiry_date and
+// membership_years.created_at are TEXT columns, and comparing them against
+// date('now') breaks on PostgreSQL (text vs date type error).
+function isoDate(offsetDays = 0) {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+}
+
+const NEEDS_RENEWAL_WINDOW_DAYS = 30;
+const RECENTLY_RENEWED_WINDOW_DAYS = 30;
+
+function viewClause(view, currentPeriodId) {
+  const today = isoDate();
+  switch (view) {
+    case 'active':
+      return {
+        sql: "(status = 'active' AND (is_lifetime = 1 OR expiry_date IS NULL OR expiry_date >= ?))",
+        params: [today],
+      };
+    case 'needs-renewal': {
+      const cutoff = isoDate(NEEDS_RENEWAL_WINDOW_DAYS);
+      let sql = `(primary_member_id IS NULL AND is_lifetime = 0
+        AND status IN ('active', 'expired')
+        AND expiry_date IS NOT NULL AND expiry_date <= ?`;
+      const params = [cutoff];
+      if (currentPeriodId) {
+        sql += ' AND NOT EXISTS (SELECT 1 FROM membership_years WHERE member_id = members.id AND membership_period_id = ?)';
+        params.push(currentPeriodId);
+      }
+      sql += ')';
+      return { sql, params };
+    }
+    case 'recently-renewed': {
+      if (!currentPeriodId) return { sql: '1 = 0', params: [] };
+      const since = `${isoDate(-RECENTLY_RENEWED_WINDOW_DAYS)} 00:00:00`;
+      return {
+        sql: 'EXISTS (SELECT 1 FROM membership_years WHERE member_id = members.id AND membership_period_id = ? AND created_at >= ?)',
+        params: [currentPeriodId, since],
+      };
+    }
+    case 'pending':
+      return { sql: "status = 'pending'", params: [] };
+    case 'lifetime':
+      return { sql: 'is_lifetime = 1', params: [] };
+    default:
+      return null;
   }
+}
+
+const SORTABLE = {
+  member_number: 'member_number %D%',
+  name: 'last_name %D%, first_name %D%',
+  email: 'email %D%',
+  year: 'membership_year %D%',
+  status: 'status %D%',
+  created_at: 'created_at %D%',
+};
+
+function orderClause(sort, dir) {
+  const template = SORTABLE[sort] || SORTABLE.created_at;
+  const d = dir === 'asc' ? 'ASC' : 'DESC';
+  return `ORDER BY ${template.replace(/%D%/g, d)}, id ASC`;
+}
+
+async function search({ search, view, currentPeriodId, status, periodId, sort, dir, limit, offset }) {
+  const clauses = [];
+  const params = [];
+
+  if (search) {
+    clauses.push('(LOWER(first_name) LIKE ? OR LOWER(last_name) LIKE ? OR LOWER(email) LIKE ? OR LOWER(member_number) LIKE ?)');
+    const s = `%${search.toLowerCase()}%`;
+    params.push(s, s, s, s);
+  }
+
+  const vc = viewClause(view, currentPeriodId);
+  if (vc) {
+    clauses.push(vc.sql);
+    params.push(...vc.params);
+  }
+
+  if (status === 'active') {
+    clauses.push("(status = 'active' AND (is_lifetime = 1 OR expiry_date IS NULL OR expiry_date >= ?))");
+    params.push(isoDate());
+  } else if (status === 'expired') {
+    clauses.push("(status != 'cancelled' AND is_lifetime = 0 AND expiry_date IS NOT NULL AND expiry_date < ?)");
+    params.push(isoDate());
+  } else if (status === 'pending' || status === 'cancelled') {
+    clauses.push('status = ?');
+    params.push(status);
+  }
+
+  if (periodId) {
+    clauses.push('id IN (SELECT member_id FROM membership_years WHERE membership_period_id = ?)');
+    params.push(periodId);
+  }
+
+  const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
   const totalRow = await db.get(`SELECT COUNT(*) as c FROM members ${where}`, ...params);
   const total = totalRow ? totalRow.c : 0;
-  const members = await db.all(`SELECT * FROM members ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`, ...params, limit, offset);
+
+  let sql = `SELECT * FROM members ${where} ${orderClause(sort, dir)}`;
+  const listParams = [...params];
+  if (limit !== undefined) {
+    sql += ' LIMIT ? OFFSET ?';
+    listParams.push(limit, offset || 0);
+  }
+  const members = await db.all(sql, ...listParams);
   return { members, total };
+}
+
+async function countView(view, currentPeriodId) {
+  const vc = viewClause(view, currentPeriodId);
+  const where = vc ? `WHERE ${vc.sql}` : '';
+  const row = await db.get(`SELECT COUNT(*) as c FROM members ${where}`, ...(vc ? vc.params : []));
+  return row ? row.c : 0;
+}
+
+async function countByView(currentPeriodId) {
+  const [all, active, needsRenewal, recentlyRenewed, pending, lifetime] = await Promise.all([
+    countView('all', currentPeriodId),
+    countView('active', currentPeriodId),
+    countView('needs-renewal', currentPeriodId),
+    countView('recently-renewed', currentPeriodId),
+    countView('pending', currentPeriodId),
+    countView('lifetime', currentPeriodId),
+  ]);
+  return { all, active, needsRenewal, recentlyRenewed, pending, lifetime };
 }
 
 async function listRecent(limit) {
@@ -459,6 +575,7 @@ module.exports = {
   countActive,
   countByYear,
   search,
+  countByView,
   listRecent,
   listAll,
   listActiveMembers,

--- a/db/repos/membershipYears.js
+++ b/db/repos/membershipYears.js
@@ -56,4 +56,9 @@ async function findByPeriod(periodId) {
     );
 }
 
-module.exports = {enroll, isEnrolled, findByMember, findByPeriod};
+async function countByPeriod(periodId) {
+    const row = await db.get('SELECT COUNT(*) as c FROM membership_years WHERE membership_period_id = ?', periodId);
+    return row ? row.c : 0;
+}
+
+module.exports = {enroll, isEnrolled, findByMember, findByPeriod, countByPeriod};

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -168,6 +168,17 @@
   box-shadow: 0 1px 3px rgba(0,0,0,0.08);
 }
 
+a.stat-card {
+  display: block;
+  text-decoration: none;
+  transition: box-shadow 0.15s ease, transform 0.15s ease;
+}
+
+a.stat-card:hover {
+  box-shadow: 0 3px 8px rgba(0,0,0,0.14);
+  transform: translateY(-1px);
+}
+
 .stat-number {
   font-size: 2.25rem;
   font-weight: 700;
@@ -328,6 +339,94 @@
   outline: none;
   border-color: #002a5c;
   box-shadow: 0 0 0 3px rgba(0,42,92,0.1);
+}
+
+.search-form-wide {
+  flex: 1;
+  flex-wrap: wrap;
+}
+
+.search-form-wide input[type="search"] {
+  flex: 1;
+  min-width: 280px;
+  max-width: 480px;
+}
+
+.search-form-wide select {
+  padding: 0.625rem 0.875rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  min-height: 40px;
+  background: #fff;
+}
+
+.toolbar-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+/* === View pills === */
+.view-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.view-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.4rem 0.9rem;
+  border: 1px solid #ccc;
+  border-radius: 999px;
+  background: #fff;
+  color: #333;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.view-pill:hover {
+  border-color: #002a5c;
+  color: #002a5c;
+}
+
+.view-pill-active,
+.view-pill-active:hover {
+  background: #002a5c;
+  border-color: #002a5c;
+  color: #fff;
+}
+
+.pill-count {
+  font-size: 0.75rem;
+  color: #666;
+  background: #f0f0f0;
+  border-radius: 999px;
+  padding: 0.05rem 0.5rem;
+}
+
+.view-pill-active .pill-count {
+  color: #fff;
+  background: rgba(255,255,255,0.2);
+}
+
+/* === Sortable headers === */
+.admin-table th .sort-link {
+  color: inherit;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.admin-table th .sort-link:hover {
+  color: #69be28;
+}
+
+.sort-indicator {
+  font-size: 0.7em;
 }
 
 /* === Forms === */

--- a/robot/libraries/DatabaseManager.py
+++ b/robot/libraries/DatabaseManager.py
@@ -34,8 +34,10 @@ class DatabaseManager:
         tables = [
             'membership_cards',
             'emails_log',
+            'membership_years',
             'payments',
             'members',
+            'membership_periods',
             'announcements',
             'gallery_images',
             'bios',
@@ -46,6 +48,7 @@ class DatabaseManager:
         self.conn.commit()
         self.seed_settings()
         self.seed_admin()
+        self.seed_period()
 
     def seed_settings(self):
         """Insert default site_settings."""
@@ -67,6 +70,17 @@ class DatabaseManager:
                 (key, value),
             )
         self.conn.commit()
+
+    def seed_period(self, label='Robot Test Season'):
+        """Insert a membership period that is current (spans today)."""
+        cursor = self.conn.execute(
+            """INSERT INTO membership_periods
+               (label, start_date, end_date, individual_dues_cents, family_dues_cents, electronic_surcharge_cents)
+               VALUES (?, date('now', '-30 days'), date('now', '+300 days'), 1600, 2600, 0)""",
+            (label,),
+        )
+        self.conn.commit()
+        return cursor.lastrowid
 
     def seed_admin(self, email=None, first_name=None, last_name=None, role='super_admin'):
         """Insert a test admin into members and return the row ID."""

--- a/robot/tests/admin_auth.robot
+++ b/robot/tests/admin_auth.robot
@@ -17,7 +17,7 @@ Successful Login Redirects To Dashboard
     Login As Admin
     Current URL Should Contain    /admin/dashboard
     ${count}=    Get Element Count    .stat-card
-    Should Be Equal As Integers    ${count}    4
+    Should Be Equal As Integers    ${count}    7
 
 Failed Login Shows Invalid Code
     Navigate To    /admin/login

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -153,17 +153,58 @@ router.get('/dashboard', async (req, res, next) => {
 });
 
 // --- Members CRUD ---
+const MEMBER_VIEWS = ['all', 'active', 'needs-renewal', 'recently-renewed', 'pending', 'lifetime'];
+const MEMBER_SORTS = ['member_number', 'name', 'email', 'year', 'status', 'created_at'];
+const MEMBER_STATUSES = ['active', 'expired', 'pending', 'cancelled'];
+
+function parseMemberListQuery(req) {
+  return {
+    view: MEMBER_VIEWS.includes(req.query.view) ? req.query.view : 'all',
+    sort: MEMBER_SORTS.includes(req.query.sort) ? req.query.sort : 'created_at',
+    dir: req.query.dir === 'asc' ? 'asc' : 'desc',
+    search: req.query.search || '',
+    status: MEMBER_STATUSES.includes(req.query.status) ? req.query.status : '',
+    periodId: parseInt(req.query.period) || null,
+  };
+}
+
+function memberListQs(state, overrides = {}) {
+  const q = { ...state, ...overrides };
+  const params = new URLSearchParams();
+  if (q.view && q.view !== 'all') params.set('view', q.view);
+  if (q.search) params.set('search', q.search);
+  if (q.status) params.set('status', q.status);
+  if (q.period) params.set('period', q.period);
+  if (q.sort && q.sort !== 'created_at') params.set('sort', q.sort);
+  if (q.dir && q.dir !== 'desc') params.set('dir', q.dir);
+  if (q.page && q.page > 1) params.set('page', q.page);
+  const s = params.toString();
+  return s ? `?${s}` : '';
+}
+
 router.get('/members', async (req, res, next) => {
   try {
     const page = Math.max(1, parseInt(req.query.page) || 1);
     const limit = 25;
     const offset = (page - 1) * limit;
-    const search = req.query.search || '';
+    const parsed = parseMemberListQuery(req);
 
-    const { members, total } = await memberRepo.search({ search, limit, offset });
+    const currentPeriod = await periodsRepo.getCurrent();
+    const currentPeriodId = currentPeriod ? currentPeriod.id : null;
+    const [{ members, total }, counts, periods] = await Promise.all([
+      memberRepo.search({ ...parsed, currentPeriodId, limit, offset }),
+      memberRepo.countByView(currentPeriodId),
+      periodsRepo.list(),
+    ]);
     const totalPages = Math.ceil(total / limit);
 
-    res.render('admin/members/list', { members, page, totalPages, search, total });
+    const { view, sort, dir, search, status, periodId } = parsed;
+    res.render('admin/members/list', {
+      members, page, totalPages, total,
+      view, sort, dir, search, status, periodId,
+      counts, periods,
+      qs: (overrides) => memberListQs({ view, search, status, period: periodId, sort, dir }, overrides),
+    });
   } catch (err) {
     next(err);
   }
@@ -172,13 +213,16 @@ router.get('/members', async (req, res, next) => {
 router.get('/members/export', async (req, res, next) => {
   try {
     const { toCsv } = require('../services/csv');
-    const members = await memberRepo.listAll();
+    const parsed = parseMemberListQuery(req);
+    const currentPeriod = await periodsRepo.getCurrent();
+    const { members } = await memberRepo.search({ ...parsed, currentPeriodId: currentPeriod ? currentPeriod.id : null });
     const columns = ['member_number', 'first_name', 'last_name', 'email', 'phone', 'address_street', 'address_city', 'address_state', 'address_zip', 'membership_year', 'status', 'notes', 'created_at'];
     const headers = ['Member Number', 'First Name', 'Last Name', 'Email', 'Phone', 'Street', 'City', 'State', 'Zip', 'Year', 'Status', 'Notes', 'Created'];
     const csv = toCsv(members, columns, headers);
     const date = new Date().toISOString().slice(0, 10);
+    const viewPart = parsed.view !== 'all' ? `${parsed.view}-` : '';
     res.setHeader('Content-Type', 'text/csv');
-    res.setHeader('Content-Disposition', `attachment; filename="ysh-members-${date}.csv"`);
+    res.setHeader('Content-Disposition', `attachment; filename="ysh-members-${viewPart}${date}.csv"`);
     res.send(csv);
   } catch (err) {
     next(err);

--- a/services/dashboard.js
+++ b/services/dashboard.js
@@ -1,18 +1,28 @@
 const memberRepo = require('../db/repos/members');
 const paymentRepo = require('../db/repos/payments');
 const emailLogRepo = require('../db/repos/emailLog');
+const periodsRepo = require('../db/repos/membershipPeriods');
+const membershipYearsRepo = require('../db/repos/membershipYears');
 
 async function getStats() {
-  const [totalMembers, activeMembers, totalRevenue, emailsSent] = await Promise.all([
-    memberRepo.countAll(),
-    memberRepo.countActive(),
+  const currentPeriod = await periodsRepo.getCurrent();
+  const currentPeriodId = currentPeriod ? currentPeriod.id : null;
+
+  const [counts, currentPeriodEnrollment, totalRevenue, emailsSent] = await Promise.all([
+    memberRepo.countByView(currentPeriodId),
+    currentPeriodId ? membershipYearsRepo.countByPeriod(currentPeriodId) : 0,
     paymentRepo.sumCompletedCents(),
     emailLogRepo.countAll()
   ]);
 
   return {
-    totalMembers,
-    activeMembers,
+    totalMembers: counts.all,
+    activeMembers: counts.active,
+    needsRenewal: counts.needsRenewal,
+    pendingMembers: counts.pending,
+    currentPeriodEnrollment,
+    currentPeriodId,
+    currentPeriodLabel: currentPeriod ? currentPeriod.label : null,
     totalRevenue,
     emailsSent,
   };

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -17,13 +17,14 @@ function buildMember(overrides = {}) {
 function insertMember(db, overrides = {}) {
   const m = buildMember(overrides);
   const info = db.prepare(
-    `INSERT INTO members (first_name, last_name, email, phone, address_street, address_city, address_state, address_zip, membership_year, status, member_number, membership_type, primary_member_id)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    `INSERT INTO members (first_name, last_name, email, phone, address_street, address_city, address_state, address_zip, membership_year, status, member_number, membership_type, primary_member_id, expiry_date, is_lifetime)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(
     m.first_name, m.last_name, m.email, m.phone,
     m.address_street, m.address_city, m.address_state, m.address_zip,
     m.membership_year, m.status, m.member_number || null,
-    m.membership_type || 'individual', m.primary_member_id || null
+    m.membership_type || 'individual', m.primary_member_id || null,
+    m.expiry_date || null, m.is_lifetime ? 1 : 0
   );
   return { ...m, id: info.lastInsertRowid };
 }
@@ -141,11 +142,16 @@ function insertPeriod(db, overrides = {}) {
     return {...p, id: info.lastInsertRowid};
 }
 
-function enrollMember(db, memberId, periodId, paymentId = null) {
-    const info = db.prepare(
-        `INSERT OR IGNORE INTO membership_years (member_id, membership_period_id, payment_id)
+function enrollMember(db, memberId, periodId, paymentId = null, createdAt = null) {
+    const info = createdAt
+        ? db.prepare(
+            `INSERT OR IGNORE INTO membership_years (member_id, membership_period_id, payment_id, created_at)
+     VALUES (?, ?, ?, ?)`
+        ).run(memberId, periodId, paymentId, createdAt)
+        : db.prepare(
+            `INSERT OR IGNORE INTO membership_years (member_id, membership_period_id, payment_id)
      VALUES (?, ?, ?)`
-    ).run(memberId, periodId, paymentId);
+        ).run(memberId, periodId, paymentId);
     return {id: info.lastInsertRowid, member_id: memberId, membership_period_id: periodId, payment_id: paymentId};
 }
 

--- a/test/repos/members.test.js
+++ b/test/repos/members.test.js
@@ -2,7 +2,13 @@ jest.mock('../../db/database', () => require('../helpers/setupDb'));
 
 const db = require('../../db/database');
 const memberRepo = require('../../db/repos/members');
-const { insertMember, insertAdmin, insertFamilyMembership } = require('../helpers/fixtures');
+const { insertMember, insertAdmin, insertFamilyMembership, insertPeriod, enrollMember } = require('../helpers/fixtures');
+
+function isoDate(offsetDays = 0) {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+}
 
 beforeEach(() => {
   db.__resetTestDb();
@@ -149,6 +155,170 @@ describe('search', () => {
     expect((await memberRepo.search({ search: 'alice@example.com', limit: 25, offset: 0 })).total).toBe(1);
     // Member number match ignoring case.
     expect((await memberRepo.search({ search: 'ysh-0042', limit: 25, offset: 0 })).total).toBe(1);
+  });
+});
+
+describe('search views', () => {
+  test('view=active includes future/null expiry and lifetime, excludes lapsed and pending', async () => {
+    const testDb = db.__getCurrentDb();
+    insertMember(testDb, { email: 'future@t.com', status: 'active', expiry_date: isoDate(30) });
+    insertMember(testDb, { email: 'noexpiry@t.com', status: 'active' });
+    insertMember(testDb, { email: 'life@t.com', status: 'active', is_lifetime: 1, expiry_date: isoDate(-400) });
+    insertMember(testDb, { email: 'lapsed@t.com', status: 'active', expiry_date: isoDate(-1) });
+    insertMember(testDb, { email: 'pending@t.com', status: 'pending' });
+
+    const { members, total } = await memberRepo.search({ view: 'active' });
+    expect(total).toBe(3);
+    const emails = members.map(m => m.email).sort();
+    expect(emails).toEqual(['future@t.com', 'life@t.com', 'noexpiry@t.com']);
+  });
+
+  test('view=needs-renewal matches expiring primaries not enrolled in current period', async () => {
+    const testDb = db.__getCurrentDb();
+    const period = insertPeriod(testDb);
+    const due = insertMember(testDb, { email: 'due@t.com', status: 'active', expiry_date: isoDate(10) });
+    const enrolled = insertMember(testDb, { email: 'renewed@t.com', status: 'active', expiry_date: isoDate(10) });
+    enrollMember(testDb, enrolled.id, period.id);
+    insertMember(testDb, { email: 'life@t.com', status: 'active', is_lifetime: 1, expiry_date: isoDate(10) });
+    insertMember(testDb, { email: 'sub@t.com', status: 'active', expiry_date: isoDate(10), primary_member_id: due.id });
+    insertMember(testDb, { email: 'noexpiry@t.com', status: 'active' });
+    insertMember(testDb, { email: 'cancelled@t.com', status: 'cancelled', expiry_date: isoDate(10) });
+    insertMember(testDb, { email: 'farfuture@t.com', status: 'active', expiry_date: isoDate(120) });
+
+    const { members } = await memberRepo.search({ view: 'needs-renewal', currentPeriodId: period.id });
+    expect(members.map(m => m.email)).toEqual(['due@t.com']);
+  });
+
+  test('view=needs-renewal without a current period degrades to expiring soon', async () => {
+    const testDb = db.__getCurrentDb();
+    insertMember(testDb, { email: 'due@t.com', status: 'active', expiry_date: isoDate(10) });
+    const { total } = await memberRepo.search({ view: 'needs-renewal', currentPeriodId: null });
+    expect(total).toBe(1);
+  });
+
+  test('view=recently-renewed includes only recent current-period enrollments', async () => {
+    const testDb = db.__getCurrentDb();
+    const period = insertPeriod(testDb);
+    const oldPeriod = insertPeriod(testDb, { label: '2024-25 Season', start_date: '2024-04-01', end_date: '2025-07-31' });
+    const recent = insertMember(testDb, { email: 'recent@t.com', status: 'active' });
+    enrollMember(testDb, recent.id, period.id);
+    const stale = insertMember(testDb, { email: 'stale@t.com', status: 'active' });
+    enrollMember(testDb, stale.id, period.id, null, `${isoDate(-40)} 12:00:00`);
+    const prior = insertMember(testDb, { email: 'prior@t.com', status: 'active' });
+    enrollMember(testDb, prior.id, oldPeriod.id);
+
+    const { members } = await memberRepo.search({ view: 'recently-renewed', currentPeriodId: period.id });
+    expect(members.map(m => m.email)).toEqual(['recent@t.com']);
+
+    const none = await memberRepo.search({ view: 'recently-renewed', currentPeriodId: null });
+    expect(none.total).toBe(0);
+  });
+
+  test('view=pending and view=lifetime filter directly', async () => {
+    const testDb = db.__getCurrentDb();
+    insertMember(testDb, { email: 'p@t.com', status: 'pending' });
+    insertMember(testDb, { email: 'l@t.com', status: 'active', is_lifetime: 1 });
+    insertMember(testDb, { email: 'a@t.com', status: 'active' });
+
+    expect((await memberRepo.search({ view: 'pending' })).members.map(m => m.email)).toEqual(['p@t.com']);
+    expect((await memberRepo.search({ view: 'lifetime' })).members.map(m => m.email)).toEqual(['l@t.com']);
+  });
+
+  test('search OR group is parenthesized so views still constrain results', async () => {
+    const testDb = db.__getCurrentDb();
+    // Both match search 'doe'; only one is pending. Without parens around the
+    // search ORs, the trailing OR would leak past the view AND-clause.
+    insertMember(testDb, { email: 'doe1@t.com', last_name: 'Doe', status: 'pending' });
+    insertMember(testDb, { email: 'doe2@t.com', last_name: 'Doe', status: 'active' });
+
+    const { members, total } = await memberRepo.search({ search: 'doe', view: 'pending' });
+    expect(total).toBe(1);
+    expect(members[0].email).toBe('doe1@t.com');
+  });
+
+  test('period filter restricts to enrolled members', async () => {
+    const testDb = db.__getCurrentDb();
+    const period = insertPeriod(testDb);
+    const inPeriod = insertMember(testDb, { email: 'in@t.com', status: 'active' });
+    enrollMember(testDb, inPeriod.id, period.id);
+    insertMember(testDb, { email: 'out@t.com', status: 'active' });
+
+    const { members } = await memberRepo.search({ periodId: period.id });
+    expect(members.map(m => m.email)).toEqual(['in@t.com']);
+  });
+
+  test('status=expired derives from expiry_date', async () => {
+    const testDb = db.__getCurrentDb();
+    insertMember(testDb, { email: 'lapsed@t.com', status: 'active', expiry_date: isoDate(-5) });
+    insertMember(testDb, { email: 'current@t.com', status: 'active', expiry_date: isoDate(5) });
+    insertMember(testDb, { email: 'cancelled@t.com', status: 'cancelled', expiry_date: isoDate(-5) });
+
+    const { members } = await memberRepo.search({ status: 'expired' });
+    expect(members.map(m => m.email)).toEqual(['lapsed@t.com']);
+  });
+});
+
+describe('search sorting', () => {
+  test('sorts by name asc using last then first name', async () => {
+    const testDb = db.__getCurrentDb();
+    insertMember(testDb, { email: 'z@t.com', first_name: 'Zed', last_name: 'Alpha' });
+    insertMember(testDb, { email: 'a@t.com', first_name: 'Amy', last_name: 'Zulu' });
+    insertMember(testDb, { email: 'b@t.com', first_name: 'Amy', last_name: 'Alpha' });
+
+    const { members } = await memberRepo.search({ sort: 'name', dir: 'asc' });
+    expect(members.map(m => m.email)).toEqual(['b@t.com', 'z@t.com', 'a@t.com']);
+  });
+
+  test('unknown sort and dir fall back to created_at desc without error', async () => {
+    const testDb = db.__getCurrentDb();
+    insertMember(testDb, { email: 'a@t.com' });
+    insertMember(testDb, { email: 'b@t.com' });
+
+    const { members } = await memberRepo.search({ sort: 'evil; DROP TABLE members', dir: 'sideways' });
+    expect(members).toHaveLength(2);
+  });
+
+  test('omitting limit returns all rows (export path)', async () => {
+    const testDb = db.__getCurrentDb();
+    for (let i = 0; i < 30; i++) {
+      insertMember(testDb, { email: `m${i}@t.com` });
+    }
+    const { members, total } = await memberRepo.search({});
+    expect(total).toBe(30);
+    expect(members).toHaveLength(30);
+  });
+});
+
+describe('countByView', () => {
+  test('returns counts for every pill', async () => {
+    const testDb = db.__getCurrentDb();
+    const period = insertPeriod(testDb);
+    const active = insertMember(testDb, { email: 'active@t.com', status: 'active', expiry_date: isoDate(60) });
+    enrollMember(testDb, active.id, period.id);
+    insertMember(testDb, { email: 'due@t.com', status: 'active', expiry_date: isoDate(10) });
+    insertMember(testDb, { email: 'pending@t.com', status: 'pending' });
+    insertMember(testDb, { email: 'life@t.com', status: 'active', is_lifetime: 1 });
+
+    const counts = await memberRepo.countByView(period.id);
+    expect(counts).toEqual({
+      all: 4,
+      active: 3,
+      needsRenewal: 1,
+      recentlyRenewed: 1,
+      pending: 1,
+      lifetime: 1,
+    });
+  });
+
+  test('null current period zeroes recently-renewed', async () => {
+    const testDb = db.__getCurrentDb();
+    const period = insertPeriod(testDb);
+    const m = insertMember(testDb, { email: 'a@t.com', status: 'active' });
+    enrollMember(testDb, m.id, period.id);
+
+    const counts = await memberRepo.countByView(null);
+    expect(counts.recentlyRenewed).toBe(0);
+    expect(counts.all).toBe(1);
   });
 });
 

--- a/test/routes/admin-members.test.js
+++ b/test/routes/admin-members.test.js
@@ -1,7 +1,7 @@
 jest.mock('../../db/database', () => require('../helpers/setupDb'));
 
 const db = require('../../db/database');
-const { insertAdmin, insertMember } = require('../helpers/fixtures');
+const { insertAdmin, insertMember, insertPeriod, enrollMember } = require('../helpers/fixtures');
 
 const mockHandlers = {};
 jest.mock('express', () => {
@@ -29,6 +29,111 @@ beforeEach(() => {
   db.__resetTestDb();
   Object.keys(mockHandlers).forEach(k => delete mockHandlers[k]);
   jest.isolateModules(() => { require('../../routes/admin'); });
+});
+
+describe('GET /members (views, sorting, filters)', () => {
+  test('view=pending renders only pending members with pill counts', async () => {
+    insertMember(db, { email: 'p@t.com', status: 'pending' });
+    insertMember(db, { email: 'a@t.com', status: 'active' });
+
+    const req = mockReq({ query: { view: 'pending' } });
+    const res = mockRes();
+    await mockHandlers['GET /members'](req, res);
+
+    expect(res.render).toHaveBeenCalledWith('admin/members/list', expect.objectContaining({
+      view: 'pending',
+      counts: expect.objectContaining({ all: 2, pending: 1 }),
+    }));
+    const locals = res.render.mock.calls[0][1];
+    expect(locals.members.map(m => m.email)).toEqual(['p@t.com']);
+  });
+
+  test('invalid view, sort, and dir are sanitized to defaults', async () => {
+    insertMember(db, { email: 'a@t.com' });
+
+    const req = mockReq({ query: { view: 'nonsense', sort: 'evil', dir: 'up' } });
+    const res = mockRes();
+    await mockHandlers['GET /members'](req, res);
+
+    const locals = res.render.mock.calls[0][1];
+    expect(locals.view).toBe('all');
+    expect(locals.sort).toBe('created_at');
+    expect(locals.dir).toBe('desc');
+    expect(locals.members).toHaveLength(1);
+  });
+
+  test('period param filters to enrolled members', async () => {
+    const period = insertPeriod(db);
+    const enrolled = insertMember(db, { email: 'in@t.com', status: 'active' });
+    enrollMember(db, enrolled.id, period.id);
+    insertMember(db, { email: 'out@t.com', status: 'active' });
+
+    const req = mockReq({ query: { period: String(period.id) } });
+    const res = mockRes();
+    await mockHandlers['GET /members'](req, res);
+
+    const locals = res.render.mock.calls[0][1];
+    expect(locals.members.map(m => m.email)).toEqual(['in@t.com']);
+    expect(locals.periods.map(p => p.id)).toContain(period.id);
+  });
+
+  test('qs helper preserves state and omits defaults', async () => {
+    insertMember(db, { email: 'a@t.com' });
+
+    const req = mockReq({ query: { view: 'lifetime', sort: 'name', dir: 'asc' } });
+    const res = mockRes();
+    await mockHandlers['GET /members'](req, res);
+
+    const { qs } = res.render.mock.calls[0][1];
+    expect(qs({})).toBe('?view=lifetime&sort=name&dir=asc');
+    expect(qs({ view: 'all' })).toBe('?sort=name&dir=asc');
+    expect(qs({ page: 2 })).toBe('?view=lifetime&sort=name&dir=asc&page=2');
+  });
+
+  test('clear-filters override drops search/status/period but keeps view and sort', async () => {
+    const period = insertPeriod(db);
+    insertMember(db, { email: 'a@t.com' });
+
+    const req = mockReq({ query: { view: 'active', sort: 'name', dir: 'asc', search: 'smith', status: 'active', period: String(period.id) } });
+    const res = mockRes();
+    await mockHandlers['GET /members'](req, res);
+
+    const { qs } = res.render.mock.calls[0][1];
+    expect(qs({ search: '', status: '', period: '', page: 1 })).toBe('?view=active&sort=name&dir=asc');
+  });
+});
+
+describe('GET /members/export (filter-aware)', () => {
+  function mockCsvRes() {
+    const res = { headers: {}, body: null, setHeader(k, v) { res.headers[k] = v; }, send(b) { res.body = b; } };
+    return res;
+  }
+
+  test('honors view and search params', async () => {
+    insertMember(db, { email: 'life@t.com', first_name: 'Lila', status: 'active', is_lifetime: 1 });
+    insertMember(db, { email: 'reg@t.com', first_name: 'Reggie', status: 'active' });
+
+    const req = mockReq({ query: { view: 'lifetime' } });
+    const res = mockCsvRes();
+    await mockHandlers['GET /members/export'](req, res);
+
+    expect(res.body).toContain('Lila');
+    expect(res.body).not.toContain('Reggie');
+    expect(res.headers['Content-Disposition']).toContain('ysh-members-lifetime-');
+  });
+
+  test('exports everyone when no params (backward compat)', async () => {
+    insertMember(db, { email: 'a@t.com', first_name: 'Alice' });
+    insertMember(db, { email: 'b@t.com', first_name: 'Bob' });
+
+    const req = mockReq({ query: {} });
+    const res = mockCsvRes();
+    await mockHandlers['GET /members/export'](req, res);
+
+    expect(res.body).toContain('Alice');
+    expect(res.body).toContain('Bob');
+    expect(res.headers['Content-Disposition']).toContain('ysh-members-2');
+  });
 });
 
 describe('POST /members/:id/delete', () => {

--- a/views/admin/dashboard.pug
+++ b/views/admin/dashboard.pug
@@ -5,13 +5,23 @@ block page_title
 
 block content
   .stats-grid
-    .stat-card
+    a.stat-card(href="/admin/members")
       .stat-number= stats.totalMembers
       .stat-label Total Members
-    .stat-card
+    a.stat-card(href="/admin/members?view=active")
       .stat-number= stats.activeMembers
       .stat-label Active Members
-    .stat-card
+    a.stat-card(href="/admin/members?view=needs-renewal")
+      .stat-number= stats.needsRenewal
+      .stat-label Needs Renewal
+    a.stat-card(href="/admin/members?view=pending")
+      .stat-number= stats.pendingMembers
+      .stat-label Pending
+    if stats.currentPeriodLabel
+      a.stat-card(href=`/admin/members?period=${stats.currentPeriodId}`)
+        .stat-number= stats.currentPeriodEnrollment
+        .stat-label= `Enrolled ${stats.currentPeriodLabel}`
+    a.stat-card(href="/admin/payments")
       .stat-number $#{(stats.totalRevenue / 100).toFixed(2)}
       .stat-label Total Revenue
     .stat-card

--- a/views/admin/members/list.pug
+++ b/views/admin/members/list.pug
@@ -3,24 +3,59 @@ extends ../layout
 block page_title
   | Members
 
+mixin sortTh(key, label)
+  - const isActive = sort === key
+  - const nextDir = isActive && dir === 'asc' ? 'desc' : 'asc'
+  th
+    a.sort-link(href=`/admin/members${qs({sort: key, dir: nextDir, page: 1})}`)
+      = label
+      if isActive
+        span.sort-indicator= dir === 'asc' ? ' ▲' : ' ▼'
+
 block content
+  .view-pills
+    - const pills = [['all', 'All', counts.all], ['active', 'Active', counts.active], ['needs-renewal', 'Needs renewal', counts.needsRenewal], ['recently-renewed', 'Recently renewed', counts.recentlyRenewed], ['pending', 'Pending', counts.pending], ['lifetime', 'Lifetime', counts.lifetime]]
+    each pill in pills
+      a(class=`view-pill${view === pill[0] ? ' view-pill-active' : ''}` href=`/admin/members${qs({view: pill[0], page: 1})}`)
+        = pill[1]
+        span.pill-count= pill[2]
+
   .admin-toolbar
-    form.search-form(method="GET" action="/admin/members")
-      input(type="text" name="search" placeholder="Search members..." value=search)
+    form.search-form.search-form-wide(method="GET" action="/admin/members")
+      if view !== 'all'
+        input(type="hidden" name="view" value=view)
+      if sort !== 'created_at'
+        input(type="hidden" name="sort" value=sort)
+      if dir !== 'desc'
+        input(type="hidden" name="dir" value=dir)
+      input(type="search" name="search" placeholder="Search name, email, or member number..." value=search)
+      select(name="period" onchange="this.form.submit()")
+        option(value="" selected=!periodId) All periods
+        each p in periods
+          option(value=p.id selected=periodId === p.id)= p.label
+      select(name="status" onchange="this.form.submit()")
+        option(value="" selected=!status) Any status
+        option(value="active" selected=status === 'active') Active
+        option(value="expired" selected=status === 'expired') Expired
+        option(value="pending" selected=status === 'pending') Pending
+        option(value="cancelled" selected=status === 'cancelled') Cancelled
       button.btn(type="submit") Search
-    a.btn(href="/admin/members/new") + New Member
-    a.btn-outline(href="/admin/members/export") Export CSV
+      if search || status || periodId
+        a.btn-outline(href=`/admin/members${qs({search: '', status: '', period: '', page: 1})}`) Clear filters
+    .toolbar-actions
+      a.btn(href="/admin/members/new") + New Member
+      a.btn-outline(href=`/admin/members/export${qs({})}`) Export CSV
 
   if members.length
     table.admin-table
       thead
         tr
-          th Number
-          th Name
-          th Email
+          +sortTh('member_number', 'Number')
+          +sortTh('name', 'Name')
+          +sortTh('email', 'Email')
           th Type
-          th Status
-          th Year
+          +sortTh('status', 'Status')
+          +sortTh('year', 'Year')
           th Actions
       tbody
         each m in members
@@ -41,9 +76,12 @@ block content
     if totalPages > 1
       .pagination
         if page > 1
-          a(href=`/admin/members?page=${page - 1}&search=${search}`) &laquo; Prev
+          a(href=`/admin/members${qs({page: page - 1})}`) &laquo; Prev
         span Page #{page} of #{totalPages} (#{total} total)
         if page < totalPages
-          a(href=`/admin/members?page=${page + 1}&search=${search}`) Next &raquo;
+          a(href=`/admin/members${qs({page: page + 1})}`) Next &raquo;
   else
-    p.text-muted No members found.
+    if view !== 'all' || search || periodId
+      p.text-muted No members match this view or search.
+    else
+      p.text-muted No members found.


### PR DESCRIPTION
Re-lands the filters feature (previously #69, reverted in #72) with date comparisons bound as JS-computed strings for PG compatibility. Adds view pills with counts, sortable columns, status and period dropdowns, filter-aware CSV export, and a Clear filters button that resets search/status/period while preserving view and sort.

## Checklist
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] No `.env` or secrets committed
