### PR TITLE
Reuse unexpired renewal tokens instead of minting new ones

### DIFF
--- a/services/renewal.js
+++ b/services/renewal.js
@@ -4,8 +4,16 @@ const settingsRepo = require('../db/repos/settings');
 const emailService = require('./email');
 const logger = require('./logger');
 
+// Reuses the member's current token when it hasn't expired, so a member who requests
+// several reminders can use the link in any of them — not just the newest email.
 async function generateRenewalToken(memberId) {
-    const token = crypto.randomBytes(32).toString('hex');
+    const member = await membersRepo.findById(memberId);
+    const stillValid = member
+        && member.renewal_token
+        && member.renewal_token_expires_at
+        && member.renewal_token_expires_at > new Date().toISOString();
+
+    const token = stillValid ? member.renewal_token : crypto.randomBytes(32).toString('hex');
     const expiresAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(); // 30 days
     await membersRepo.setRenewalToken(memberId, token, expiresAt);
     return token;

--- a/test/services/renewal.test.js
+++ b/test/services/renewal.test.js
@@ -49,6 +49,50 @@ describe('generateRenewalToken', () => {
     expect(expiryMs).toBeGreaterThanOrEqual(before + thirtyDaysMs - 1000);
     expect(expiryMs).toBeLessThanOrEqual(after + thirtyDaysMs + 1000);
     });
+
+    test('reuses the existing token while it is still valid', async () => {
+        const testDb = getTestDb();
+        const member = insertMember(testDb, {email: 'c@c.com', status: 'active'});
+
+        const first = await renewalService.generateRenewalToken(member.id);
+        const second = await renewalService.generateRenewalToken(member.id);
+
+        expect(second).toBe(first);
+    });
+
+    test('extends the expiry of a reused token', async () => {
+        const testDb = getTestDb();
+        const member = insertMember(testDb, {email: 'd@d.com', status: 'active'});
+
+        await renewalService.generateRenewalToken(member.id);
+        const firstExpiry = testDb.prepare('SELECT renewal_token_expires_at FROM members WHERE id = ?')
+            .get(member.id).renewal_token_expires_at;
+
+        // Wind the stored expiry back a day so the refresh is unambiguous
+        const rolledBack = new Date(new Date(firstExpiry).getTime() - 24 * 60 * 60 * 1000).toISOString();
+        testDb.prepare('UPDATE members SET renewal_token_expires_at = ? WHERE id = ?').run(rolledBack, member.id);
+
+        await renewalService.generateRenewalToken(member.id);
+        const secondExpiry = testDb.prepare('SELECT renewal_token_expires_at FROM members WHERE id = ?')
+            .get(member.id).renewal_token_expires_at;
+
+        expect(new Date(secondExpiry).getTime()).toBeGreaterThan(new Date(rolledBack).getTime());
+    });
+
+    test('mints a new token when the existing one has expired', async () => {
+        const testDb = getTestDb();
+        const member = insertMember(testDb, {email: 'e@e.com', status: 'active'});
+
+        const first = await renewalService.generateRenewalToken(member.id);
+
+        const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+        testDb.prepare('UPDATE members SET renewal_token_expires_at = ? WHERE id = ?').run(yesterday, member.id);
+
+        const second = await renewalService.generateRenewalToken(member.id);
+
+        expect(second).not.toBe(first);
+        expect(second.length).toBe(64);
+    });
 });
 
 describe('findMembersNeedingRenewal', () => {


### PR DESCRIPTION
## Description
Introduces token recycling for repeat renewal requests.

## Checklist
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] No `.env` or secrets committed