### PR TITLE
Fix filter dropdowns that CSP silently disabled

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,25 @@ robot/                       # Robot Framework end-to-end tests (Browser/Playwri
 - Prefix unused params with `_` (e.g. `_next`, `_e`)
 - No TypeScript, no semicolons-optional — semicolons are used throughout
 
+## Client-side JS in views
+
+**Inline event handler attributes do not work.** helmet sends `script-src-attr 'none'`, so
+`onchange="this.form.submit()"` and `onclick="return confirm(...)"` in a Pug template never
+fire, and nothing appears in the console to say why. This has silently broken three
+features (the report period filter, the members list period/status filters, and the
+confirmation on the Demote button).
+
+Put the behavior in `public/js/admin.js` instead, driven by a data attribute — that file is
+served from `'self'`, which the CSP allows. Two hooks already exist:
+
+- `data-auto-submit` on a form control submits its form on change
+- `data-confirm="Are you sure?"` on a form confirms before submit
+
+Inline `<style>` and `style=` attributes are fine; `style-src` includes `'unsafe-inline'`.
+Only scripts are restricted. When adding a filter control, cover it with a Robot test that
+actually changes the control — a test that navigates straight to `?filter=value` passes
+whether or not the control works.
+
 ## Testing patterns
 
 Three layers: Jest unit/repo tests, Jest HTTP integration tests through supertest, and Robot Framework

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -30,6 +30,15 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   });
 
+  // Submit a filter form as soon as its control changes. This lives here rather than in an
+  // inline onchange attribute because helmet sends `script-src-attr 'none'`, which blocks
+  // inline event handlers outright — an onchange there never fires at all.
+  document.querySelectorAll('[data-auto-submit]').forEach(function (control) {
+    control.addEventListener('change', function () {
+      if (control.form) control.form.submit();
+    });
+  });
+
   // Image preview on file input change
   document.querySelectorAll('input[type="file"][accept="image/*"]').forEach(function (input) {
     input.addEventListener('change', function () {

--- a/robot/tests/admin_council_report.robot
+++ b/robot/tests/admin_council_report.robot
@@ -34,7 +34,59 @@ Preview Shows Enrolled Member Count
     Login As Admin
     Navigate To    /admin/reports/membership
     Get Text    table#report-summary    contains    Total member count
-    Get Text    button.btn[type="submit"]    contains    2 members
+    Get Text    \#download-report    contains    2 members
+
+Changing The Period Dropdown Updates The Preview
+    [Documentation]    Regression: the dropdown used an inline onchange attribute, which
+    ...    helmet blocks with script-src-attr 'none', so changing the period did nothing to
+    ...    the preview or to the period the download used.
+    ${current}=    Get Current Period Id
+    ${other}=    Seed Period    label=Older Robot Season
+    ${here}=    Seed Member    first_name=In    last_name=Current    email=in@example.com
+    ${there}=    Seed Member    first_name=Two    last_name=Older    email=one@example.com
+    ${alsothere}=    Seed Member    first_name=Three    last_name=Older    email=two@example.com
+    Enroll Member    ${here}    ${current}
+    Enroll Member    ${there}    ${other}
+    Enroll Member    ${alsothere}    ${other}
+    Login As Admin
+    Navigate To    /admin/reports/membership
+    Get Text    \#download-report    contains    1 member
+
+    ${other_value}=    Convert To String    ${other}
+    Select Options By    select[name="period"]    value    ${other_value}
+    Wait For Elements State    \#download-report    visible    timeout=10s
+    Current URL Should Contain    period=${other}
+    Get Text    \#download-report    contains    2 members
+
+Changing The Period Dropdown Changes What The Download Contains
+    ${current}=    Get Current Period Id
+    ${other}=    Seed Period    label=Older Robot Season
+    ${here}=    Seed Member    first_name=In    last_name=Current    email=in@example.com
+    ${there}=    Seed Member    first_name=Two    last_name=Older    email=one@example.com
+    Enroll Member    ${here}    ${current}
+    Enroll Member    ${there}    ${other}
+    Login As Admin
+    Navigate To    /admin/reports/membership
+    ${other_value}=    Convert To String    ${other}
+    Select Options By    select[name="period"]    value    ${other_value}
+    Wait For Elements State    \#download-report    visible    timeout=10s
+    ${file}=    Download Via Click    \#download-report
+    # The workbook follows the dropdown, not the period the page first loaded with.
+    Xlsx Cell Should Be    ${file}    C4    1
+    Xlsx Cell Should Be    ${file}    C19    Older
+
+The Apply Period Button Also Applies The Period
+    [Documentation]    The button is the fallback if the auto-submit script ever fails, so
+    ...    it has to work on its own.
+    ${other}=    Seed Period    label=Older Robot Season
+    ${there}=    Seed Member    first_name=Two    last_name=Older    email=one@example.com
+    Enroll Member    ${there}    ${other}
+    Login As Admin
+    Navigate To    /admin/reports/membership?period=${other}
+    Click    button#apply-period
+    Wait For Elements State    \#download-report    visible    timeout=10s
+    Current URL Should Contain    period=${other}
+    Get Text    \#download-report    contains    1 member
 
 Preview Lists Static Social Media Links
     Login As Admin
@@ -92,7 +144,7 @@ Download Produces A Valid Workbook In The Council Format
     Seed Bio    name=Pat President    role=President    email=president@example.com    sort_order=1
     Login As Admin
     Navigate To    /admin/reports/membership
-    ${file}=    Download Via Click    .form-actions button[type="submit"]
+    ${file}=    Download Via Click    \#download-report
 
     Xlsx Should Be A Valid Workbook    ${file}
     ${sheets}=    Get Xlsx Sheet Names    ${file}
@@ -106,7 +158,7 @@ Download Fills The Header And Board Blocks
     Seed Bio    name=Pat President    role=President    email=president@example.com    sort_order=1
     Login As Admin
     Navigate To    /admin/reports/membership
-    ${file}=    Download Via Click    .form-actions button[type="submit"]
+    ${file}=    Download Via Click    \#download-report
 
     Xlsx Cell Should Be    ${file}    C3    Yellowstone Sea Hawkers
     Xlsx Cell Should Be    ${file}    C4    1
@@ -134,7 +186,7 @@ Download Writes Each Member As Their Own Row
     Enroll Member    ${second}    ${period}
     Login As Admin
     Navigate To    /admin/reports/membership
-    ${file}=    Download Via Click    .form-actions button[type="submit"]
+    ${file}=    Download Via Click    \#download-report
 
     ${rows}=    Get Xlsx Data Rows    ${file}
     Length Should Be    ${rows}    2
@@ -157,7 +209,7 @@ Download Marks Every Member As Primary Chapter Y
     Enroll Member    ${second}    ${period}
     Login As Admin
     Navigate To    /admin/reports/membership
-    ${file}=    Download Via Click    .form-actions button[type="submit"]
+    ${file}=    Download Via Click    \#download-report
 
     Xlsx Cell Should Be    ${file}    J19    Y
     Xlsx Cell Should Be    ${file}    J20    Y
@@ -169,7 +221,7 @@ Download Flags A Board Member In Their Own Row
     Seed Bio    name=Pat President    role=Director of PR/Entertainment    email=president@example.com    sort_order=1
     Login As Admin
     Navigate To    /admin/reports/membership
-    ${file}=    Download Via Click    .form-actions button[type="submit"]
+    ${file}=    Download Via Click    \#download-report
     Xlsx Cell Should Be    ${file}    L19    Director of PR/Entertainment
 
 Download Writes Board Titles Verbatim Down Rows 6 To 15
@@ -179,7 +231,7 @@ Download Writes Board Titles Verbatim Down Rows 6 To 15
     Seed Bio    name=Bee Hanson    role=Central Council Rep    email=b@example.com    sort_order=4
     Login As Admin
     Navigate To    /admin/reports/membership
-    ${file}=    Download Via Click    .form-actions button[type="submit"]
+    ${file}=    Download Via Click    \#download-report
 
     Xlsx Cell Should Be    ${file}    G6    President
     Xlsx Cell Should Be    ${file}    G7    Vice-President
@@ -199,7 +251,7 @@ Download Honours Edited Header Fields
     Fill Text    input[name="chapter_name"]    Yellowstone Sea Hawkers Chapter
     Fill Text    input[name="month_year"]    December 2026
     Fill Text    input[name="submitted_by"]    Robot Reporter
-    ${file}=    Download Via Click    .form-actions button[type="submit"]
+    ${file}=    Download Via Click    \#download-report
 
     Xlsx Cell Should Be    ${file}    C3    Yellowstone Sea Hawkers Chapter
     Xlsx Cell Should Be    ${file}    C5    December 2026
@@ -214,14 +266,14 @@ Download Preserves The Council Template Formatting Exactly
     Enroll Member    ${id}    ${period}
     Login As Admin
     Navigate To    /admin/reports/membership
-    ${file}=    Download Via Click    .form-actions button[type="submit"]
+    ${file}=    Download Via Click    \#download-report
     Xlsx Should Match Template Formatting    ${file}    ${REPORT_TEMPLATE}
 
 Download Works For A Period With Nobody Enrolled
     Login As Admin
     Navigate To    /admin/reports/membership
-    Get Text    button.btn[type="submit"]    contains    0 members
-    ${file}=    Download Via Click    .form-actions button[type="submit"]
+    Get Text    \#download-report    contains    0 members
+    ${file}=    Download Via Click    \#download-report
     Xlsx Should Be A Valid Workbook    ${file}
     Xlsx Cell Should Be    ${file}    C4    0
     Xlsx Cell Should Be    ${file}    B19    ${EMPTY}

--- a/views/admin/admins.pug
+++ b/views/admin/admins.pug
@@ -22,9 +22,9 @@ block content
           td= admin.role === 'super_admin' ? 'Super Admin' : 'Editor'
           td= formatDate(admin.created_at)
           td
-            form(method="POST" action=`/admin/admins/${admin.id}/delete` style="display:inline")
+            form(method="POST" action=`/admin/admins/${admin.id}/delete` style="display:inline" data-confirm="Demote this admin?")
               input(type="hidden" name="_csrf" value=csrfToken)
-              button.btn.btn-sm.btn-danger(type="submit" onclick="return confirm('Demote this admin?')") Demote
+              button.btn.btn-sm.btn-danger(type="submit") Demote
 
   hr
 

--- a/views/admin/members/list.pug
+++ b/views/admin/members/list.pug
@@ -29,11 +29,11 @@ block content
       if dir !== 'desc'
         input(type="hidden" name="dir" value=dir)
       input(type="search" name="search" placeholder="Search name, email, or member number..." value=search)
-      select(name="period" onchange="this.form.submit()")
+      select(name="period" data-auto-submit)
         option(value="" selected=!periodId) All periods
         each p in periods
           option(value=p.id selected=periodId === p.id)= p.label
-      select(name="status" onchange="this.form.submit()")
+      select(name="status" data-auto-submit)
         option(value="" selected=!status) Any status
         option(value="active" selected=status === 'active') Active
         option(value="expired" selected=status === 'expired') Expired

--- a/views/admin/reports/membership.pug
+++ b/views/admin/reports/membership.pug
@@ -11,12 +11,12 @@ block content
     form(method="GET" action="/admin/reports/membership" style="margin-bottom: 1.5rem;")
         .form-group
             label(for="period") Membership period
-            select#period(name="period" onchange="this.form.submit()")
+            select#period(name="period" data-auto-submit)
                 each p in periods
                     option(value=p.id selected=(period && period.id === p.id))= `${p.label || 'Period ' + p.id} (${p.start_date} → ${p.end_date})`
             small.form-hint Everyone enrolled in this period is listed, family members included.
-        noscript
-            button.btn-outline(type="submit") Load period
+        .form-actions
+            button#apply-period.btn-outline(type="submit") Apply period
 
     if !period
         .flash.flash-error No membership periods are defined yet, so there is nothing to report.
@@ -85,4 +85,4 @@ block content
                 input#filename(type="text" name="filename" value=reportFilename)
                 small.form-hint Prefilled with the standard name — edit it if the Council asked for something else.
             .form-actions
-                button.btn(type="submit")= `Download .xlsx (${members.length} ${members.length === 1 ? 'member' : 'members'})`
+                button#download-report.btn(type="submit")= `Download .xlsx (${members.length} ${members.length === 1 ? 'member' : 'members'})`


### PR DESCRIPTION
helmet sends `script-src-attr 'none'`, which blocks inline event handler attributes outright. Every `onchange="this.form.submit()"` in the admin views therefore never fired, with no console error to point at it.

On the Council report page this made the membership period unusable: changing it did not re-render the preview, and the download form kept whatever hidden period value the page first loaded with, so neither the preview nor the exported workbook followed the dropdown. That page had only a `noscript` submit button, so there was no working way to change the period at all.

The members list was degraded rather than broken: its period and status dropdowns did nothing, and the "Search" button was the only thing that applied them. Because the CSV export link is built from the filters actually applied, exports there kept stale filters too.

On the admins page the same rule dropped the confirmation on a destructive action: `onclick="return confirm('Demote this admin?')"` never ran, so Demote fired immediately. Moved to the existing `data-confirm` hook in admin.js.

- Adds a `[data-auto-submit]` change handler to public/js/admin.js, which CSP allows because it is served from 'self', and switches all three selects to it
- Gives the report page an always-visible "Apply period" button so it works even if the script fails, and ids on both submits so they are never ambiguous

The existing Robot tests missed this because they navigated to `?period=` directly and never touched the dropdown. Three tests now drive it: the preview count updates, the downloaded workbook follows the selection, and the button works on its own. Verified they catch a regression by disabling the handler and watching the two dropdown tests fail while the button test still passes.