### PR TITLE
add Needs attention members filter for stalled signups and renewals

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ db/audit-context.js          # AsyncLocalStorage actor propagation (getActor, ru
 db/pg-translate.js           # SQLite→PostgreSQL SQL dialect translation helpers
 db/repos/                    # Data-access layer (one file per table)
   members.js                 #   CRUD + audit logging for members
+  memberAttention.js         #   "needs attention" signal predicates (stalled signups/renewals)
   payments.js                #   CRUD + audit logging for payments
   cards.js                   #   membership_cards
   auditLog.js                #   insert() + list() for audit_log table
@@ -40,6 +41,7 @@ routes/                      # Express routers (index, admin, stripe)
 services/                    # Business logic
   members.js stripe.js email.js card.js  # core domain services
   admin.js                   #   admin-specific operations
+  attention.js               #   thresholds + current period for the needs-attention filter
   auth.js                    #   password hashing / OTP
   campaigns.js               #   UTM link building, QR (PNG/SVG), campaign validation
   content.js                 #   announcements, bios, gallery CRUD
@@ -141,7 +143,13 @@ end-to-end tests in a real browser. `./scripts/check.sh` runs all of them.
 - `members.campaign_id` is the one exception: it lives only in the migrate ALTERs (and is mirrored in
   `test/helpers/db.js`), because `members` is created before `campaigns` while `campaigns.created_by`
   references `members`, and PostgreSQL rejects a forward `REFERENCES` at `CREATE TABLE` time
+- `payments.status` allows `pending`/`completed`/`failed`/`refunded`. `failed` is written only by the
+  Stripe failure webhooks (`checkout.session.expired`, `payment_intent.payment_failed`), and
+  `payments.failure_reason` holds Stripe's message. Nothing writes `refunded`.
 - Campaign tracking is documented in `docs/campaign-tracking.md`
+- The Needs attention member filter is documented in `docs/needs-attention-signals.md` — read it
+  before changing a signal predicate or threshold, and note that neither Jest nor Robot exercises
+  `pg-translate`, so those queries need a manual PostgreSQL check
 
 ## CI
 

--- a/db/migrate.js
+++ b/db/migrate.js
@@ -29,6 +29,8 @@ async function migrate() {
     const pgAlters = [
       // payments: payment_method added for offline payments
       "ALTER TABLE payments ADD COLUMN IF NOT EXISTS payment_method TEXT NOT NULL DEFAULT 'stripe'",
+      // payments: why Stripe declined, captured by the failure webhooks
+      'ALTER TABLE payments ADD COLUMN IF NOT EXISTS failure_reason TEXT',
       // members: admin columns merged from admins table
       "ALTER TABLE members ADD COLUMN IF NOT EXISTS role TEXT CHECK(role IN ('super_admin','editor'))",
       "ALTER TABLE members ADD COLUMN IF NOT EXISTS otp_hash TEXT",
@@ -331,6 +333,8 @@ async function migrate() {
     // members is created before campaigns and campaigns.created_by points back at members.
     "ALTER TABLE members ADD COLUMN campaign_id INTEGER REFERENCES campaigns(id) ON DELETE SET NULL",
     "CREATE INDEX IF NOT EXISTS idx_members_campaign ON members (campaign_id)",
+    // payments: why Stripe declined, captured by the failure webhooks
+    'ALTER TABLE payments ADD COLUMN failure_reason TEXT',
   ];
   for (const sql of auditAlters) {
     try {

--- a/db/repos/memberAttention.js
+++ b/db/repos/memberAttention.js
@@ -1,0 +1,306 @@
+const db = require('../database');
+
+/**
+ * "Needs attention" signals — members who look like they tried to join or renew and
+ * didn't finish. See docs/needs-attention-signals.md for what each signal actually
+ * proves (they are proxies, not facts) and why some tempting ones were left out.
+ *
+ * Every signal is a self-contained boolean SQL predicate correlated on `members.id`,
+ * so the same text can be OR-ed together for filtering and evaluated individually for
+ * per-row attribution. Nothing here may reference an outer alias other than `members`.
+ *
+ * Members who are cancelled or currently paid up are excluded before any signal is
+ * considered — see eligibilityGate, which is where the definition of "paid up" lives and
+ * why it is not `status = 'active'`.
+ */
+
+// Dates are computed in JS and bound as parameters, never inlined as date('now'):
+// created_at/expiry_date are TEXT columns and comparing them to a SQL date breaks on
+// PostgreSQL (text vs date). This is what caused the PR #69 revert. Deliberately a
+// local copy rather than an import from ./members, which requires this module.
+function isoDate(offsetDays = 0) {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+}
+
+// Matches the datetime('now') format used by the created_at defaults: 'YYYY-MM-DD HH:MM:SS'.
+function sqlTimestamp(date) {
+  return date.toISOString().slice(0, 19).replace('T', ' ');
+}
+
+/**
+ * Resolves the raw context into the bound values the predicates need.
+ */
+function resolve(ctx = {}) {
+  const {
+    currentPeriodId = null,
+    minReminders = 2,
+    staleHours = 24,
+    lookbackDays = 180,
+  } = ctx;
+  return {
+    currentPeriodId,
+    minReminders,
+    // Everything is bounded by a lookback window so the list is an outreach queue and
+    // not the club's entire history of failed signups.
+    windowStart: `${isoDate(-lookbackDays)} 00:00:00`,
+    // A payment younger than this is someone still filling in their card details.
+    staleCutoff: sqlTimestamp(new Date(Date.now() - staleHours * 60 * 60 * 1000)),
+    today: isoDate(),
+    // renewal_token_expires_at is written by services/renewal.js as a full ISO string
+    // (with T and Z), unlike the created_at columns — so it needs this format, not
+    // sqlTimestamp. Matches members.findByRenewalToken.
+    nowIso: new Date().toISOString(),
+  };
+}
+
+const ATTENTION_SIGNALS = [
+  {
+    key: 'repeated_reminders',
+    label: 'Reminded repeatedly, never renewed',
+    short: 'Reminded, not renewed',
+    requiresPeriod: true,
+    build: (c) => ({
+      sql: `(members.primary_member_id IS NULL AND members.is_lifetime = 0
+        AND (SELECT COUNT(*) FROM emails_log e
+             WHERE e.member_id = members.id AND e.email_type = 'renewal_reminder'
+               AND e.created_at >= ?) >= ?
+        AND NOT EXISTS (SELECT 1 FROM membership_years my
+                        WHERE my.member_id = members.id AND my.membership_period_id = ?))`,
+      params: [c.windowStart, c.minReminders, c.currentPeriodId],
+    }),
+  },
+  {
+    key: 'payment_failed',
+    label: 'Stripe reported a failed payment',
+    short: 'Payment failed',
+    requiresPeriod: false,
+    build: (c) => ({
+      // No period gate: a failed payment is worth chasing even before a season opens.
+      sql: `(EXISTS (SELECT 1 FROM payments p
+                     WHERE p.member_id = members.id AND p.status = 'failed'
+                       AND p.created_at >= ?)
+        AND NOT EXISTS (SELECT 1 FROM payments p2
+                        WHERE p2.member_id = members.id AND p2.status = 'completed'
+                          AND p2.created_at >= ?))`,
+      params: [c.windowStart, c.windowStart],
+    }),
+  },
+  {
+    key: 'stale_pending_payment',
+    label: 'Started checkout but never completed it',
+    short: 'Checkout not finished',
+    requiresPeriod: false,
+    build: (c) => ({
+      sql: `(EXISTS (SELECT 1 FROM payments p
+                     WHERE p.member_id = members.id AND p.status = 'pending'
+                       AND p.created_at >= ? AND p.created_at <= ?)
+        AND NOT EXISTS (SELECT 1 FROM payments p2
+                        WHERE p2.member_id = members.id AND p2.status = 'completed'
+                          AND p2.created_at >= ?))`,
+      params: [c.windowStart, c.staleCutoff, c.windowStart],
+    }),
+  },
+  {
+    key: 'pending_no_payment',
+    label: 'Signed up but never reached checkout',
+    short: 'Never reached checkout',
+    requiresPeriod: false,
+    build: (c) => ({
+      // The signup route creates the member before calling Stripe, so a thrown
+      // createCheckoutSession leaves a pending member with no payment rows at all.
+      sql: `(members.status = 'pending' AND members.created_at <= ?
+        AND NOT EXISTS (SELECT 1 FROM payments p WHERE p.member_id = members.id))`,
+      params: [c.staleCutoff],
+    }),
+  },
+  {
+    key: 'duplicate_pending',
+    label: 'Duplicate pending signup for this email',
+    short: 'Duplicate signup',
+    requiresPeriod: false,
+    build: () => ({
+      sql: `(members.status = 'pending' AND members.primary_member_id IS NULL
+        AND EXISTS (SELECT 1 FROM members m2
+                    WHERE m2.id <> members.id AND m2.primary_member_id IS NULL
+                      AND LOWER(m2.email) = LOWER(members.email)))`,
+      params: [],
+    }),
+  },
+  {
+    key: 'email_send_failed',
+    label: 'An email failed and nothing has reached this address since',
+    short: 'Email send failed',
+    requiresPeriod: false,
+    build: (c) => ({
+      // Matches on to_email as well as member_id because otp and contact rows are
+      // Two guards, both learned from production data:
+      //
+      // 1. The to_email fallback exists because otp and contact rows carry a null
+      //    member_id, but family sub-members share the primary's address, so an
+      //    unattributed failure would badge the whole family for one send. Restricting
+      //    the fallback to primaries flags the one person you would actually call. A
+      //    sub-member whose OWN send failed still matches on e.member_id.
+      //
+      // 2. A later successful send to the same address proves we can still reach them,
+      //    so the failure is stale. Without this, one account-level MailerSend outage
+      //    (or a trial quota limit) badges people for the entire lookback window even
+      //    though every send since has worked. Mirrors how payment_failed clears itself
+      //    once a payment completes.
+      sql: `EXISTS (SELECT 1 FROM emails_log e
+                    WHERE e.status = 'failed' AND e.created_at >= ?
+                      AND (e.member_id = members.id
+                           OR (e.member_id IS NULL
+                               AND members.primary_member_id IS NULL
+                               AND LOWER(e.to_email) = LOWER(members.email)))
+                      AND NOT EXISTS (SELECT 1 FROM emails_log s
+                                      WHERE s.status = 'sent'
+                                        AND s.created_at > e.created_at
+                                        AND LOWER(s.to_email) = LOWER(e.to_email)))`,
+      params: [c.windowStart],
+    }),
+  },
+  {
+    key: 'renewal_never_started',
+    label: 'Lapsed with an unused renewal link',
+    short: 'Renewal never started',
+    requiresPeriod: true,
+    build: (c) => ({
+      // Gated on expiry_date being in the past, and on FEWER than minReminders
+      // reminders, so this is the complement of repeated_reminders rather than a
+      // second badge on the same people. Without the expiry gate this would fire for
+      // everyone who ever got one reminder, because generateRenewalToken re-extends
+      // renewal_token_expires_at on every send.
+      sql: `(members.primary_member_id IS NULL AND members.is_lifetime = 0
+        AND members.renewal_token IS NOT NULL AND members.renewal_token_expires_at > ?
+        AND members.expiry_date IS NOT NULL AND members.expiry_date < ?
+        AND (SELECT COUNT(*) FROM emails_log e
+             WHERE e.member_id = members.id AND e.email_type = 'renewal_reminder'
+               AND e.created_at >= ?) < ?
+        AND NOT EXISTS (SELECT 1 FROM membership_years my
+                        WHERE my.member_id = members.id AND my.membership_period_id = ?))`,
+      params: [c.nowIso, c.today, c.windowStart, c.minReminders, c.currentPeriodId],
+    }),
+  },
+];
+
+const SIGNAL_KEYS = ATTENTION_SIGNALS.map(s => s.key);
+
+const SIGNAL_LABELS = ATTENTION_SIGNALS.map(({ key, label, short }) => ({ key, label, short }));
+
+// Period-dependent signals go dark rather than throwing when no season is open,
+// matching how the recently-renewed view degrades.
+const NEVER = { sql: '1 = 0', params: [] };
+
+function predicateFor(signal, c) {
+  if (signal.requiresPeriod && !c.currentPeriodId) return NEVER;
+  return signal.build(c);
+}
+
+/**
+ * Who is eligible to be flagged at all: not cancelled, and not already paid up for the
+ * current season.
+ *
+ * "Paid up" is enrollment in the current membership period — a membership_years row,
+ * which is written only by a successful payment webhook and is the authoritative record
+ * of "completed this season". Lifetime members are paid up by definition.
+ *
+ * Two definitions were tried and rejected:
+ *
+ * - `status != 'active'`. Nothing in this codebase ever writes status = 'expired' (there
+ *   is no expiry job), so a lapsed member still carries status = 'active'. This would
+ *   exclude the very people the renewal signals exist to find.
+ * - The derived good-standing test used by the `active` viewClause, which treats a NULL
+ *   expiry_date as current. Most of the membership has a NULL expiry_date because it
+ *   predates expiry tracking, so this dropped ~106 of 172 active members who genuinely
+ *   had not renewed.
+ *
+ * With no current period nobody can be enrolled, so this degrades to excluding only
+ * cancelled members rather than silently emptying the list.
+ */
+function eligibilityGate(c) {
+  const clauses = ["members.status != 'cancelled'", 'members.is_lifetime = 0'];
+  const params = [];
+  if (c.currentPeriodId) {
+    clauses.push(`NOT EXISTS (SELECT 1 FROM membership_years my
+                              WHERE my.member_id = members.id AND my.membership_period_id = ?)`);
+    params.push(c.currentPeriodId);
+  }
+  return { sql: `(${clauses.join(' AND ')})`, params };
+}
+
+/**
+ * Predicate for the needs-attention view. Pass ctx.signal to narrow to one signal
+ * instead of the full OR group.
+ */
+function attentionClause(ctx = {}) {
+  const c = resolve(ctx);
+  const selected = ctx.signal
+    ? ATTENTION_SIGNALS.filter(s => s.key === ctx.signal)
+    : ATTENTION_SIGNALS;
+
+  // An unknown signal key must not silently widen to "everyone".
+  if (!selected.length) return NEVER;
+
+  const gate = eligibilityGate(c);
+  const parts = selected.map(s => predicateFor(s, c));
+  // Param order follows the SQL text: the gate's placeholder precedes the OR group's.
+  return {
+    sql: `(${gate.sql} AND (${parts.map(p => p.sql).join(' OR ')}))`,
+    params: [...gate.params, ...parts.flatMap(p => p.params)],
+  };
+}
+
+// SQLite caps a statement at 999 bound parameters, and the CSV export runs unlimited.
+const ID_CHUNK_SIZE = 400;
+
+/**
+ * Per-member attribution: which signals fired for each of these ids.
+ *
+ * A second pass rather than extra columns on members.search(), because search() shares
+ * one param array between its COUNT and its SELECT — select-list params would desync
+ * the count. Reusing the same predicate text for both passes is what guarantees a
+ * badge can never disagree with the filter that produced the row.
+ *
+ * Returns Map<id, [{key, label, short}]>.
+ */
+async function signalsForIds(ids, ctx = {}) {
+  const result = new Map();
+  if (!ids || !ids.length) return result;
+
+  const c = resolve(ctx);
+  const parts = ATTENTION_SIGNALS.map(s => ({ signal: s, ...predicateFor(s, c) }));
+  // CASE ... THEN 1 ELSE 0 rather than a bare EXISTS: EXISTS returns a PostgreSQL
+  // boolean but a SQLite integer, and that difference would leak into the CSV.
+  const columns = parts.map(p => `CASE WHEN ${p.sql} THEN 1 ELSE 0 END AS s_${p.signal.key}`);
+  const predicateParams = parts.flatMap(p => p.params);
+
+  for (let i = 0; i < ids.length; i += ID_CHUNK_SIZE) {
+    const chunk = ids.slice(i, i + ID_CHUNK_SIZE);
+    const placeholders = chunk.map(() => '?').join(', ');
+    const rows = await db.all(
+      `SELECT id, ${columns.join(', ')} FROM members WHERE id IN (${placeholders})`,
+      ...predicateParams,
+      ...chunk
+    );
+    for (const row of rows) {
+      result.set(
+        row.id,
+        ATTENTION_SIGNALS
+          .filter(s => Number(row[`s_${s.key}`]) === 1)
+          .map(({ key, label, short }) => ({ key, label, short }))
+      );
+    }
+  }
+
+  return result;
+}
+
+module.exports = {
+  ATTENTION_SIGNALS,
+  SIGNAL_KEYS,
+  SIGNAL_LABELS,
+  attentionClause,
+  signalsForIds,
+};

--- a/db/repos/members.js
+++ b/db/repos/members.js
@@ -1,6 +1,7 @@
 const db = require('../database');
 const {getActor} = require('../audit-context');
 const auditLog = require('./auditLog');
+const memberAttention = require('./memberAttention');
 
 async function findById(id) {
   return await db.get('SELECT * FROM members WHERE id = ?', id);
@@ -121,7 +122,16 @@ function isoDate(offsetDays = 0) {
 const NEEDS_RENEWAL_WINDOW_DAYS = 30;
 const RECENTLY_RENEWED_WINDOW_DAYS = 30;
 
-function viewClause(view, currentPeriodId) {
+// Accepts either a bare currentPeriodId (the original signature, still used by
+// countByView and findNeedingRenewal) or the fuller attention context object.
+function normalizeViewCtx(ctx) {
+  if (ctx === null || ctx === undefined) return {};
+  return typeof ctx === 'object' ? ctx : { currentPeriodId: ctx };
+}
+
+function viewClause(view, ctxOrPeriodId) {
+  const ctx = normalizeViewCtx(ctxOrPeriodId);
+  const currentPeriodId = ctx.currentPeriodId ?? null;
   const today = isoDate();
   switch (view) {
     case 'active':
@@ -154,6 +164,8 @@ function viewClause(view, currentPeriodId) {
       return { sql: "status = 'pending'", params: [] };
     case 'lifetime':
       return { sql: 'is_lifetime = 1', params: [] };
+    case 'needs-attention':
+      return memberAttention.attentionClause(ctx);
     default:
       return null;
   }
@@ -174,7 +186,7 @@ function orderClause(sort, dir) {
   return `ORDER BY ${template.replace(/%D%/g, d)}, id ASC`;
 }
 
-async function search({ search, view, currentPeriodId, status, periodId, sort, dir, limit, offset }) {
+async function search({ search, view, currentPeriodId, status, periodId, sort, dir, limit, offset, signal, minReminders, staleHours, lookbackDays }) {
   const clauses = [];
   const params = [];
 
@@ -184,7 +196,15 @@ async function search({ search, view, currentPeriodId, status, periodId, sort, d
     params.push(s, s, s, s);
   }
 
-  const vc = viewClause(view, currentPeriodId);
+  // `signal` narrows the needs-attention view to a single signal; it is meaningless
+  // under any other view, so it is not passed through.
+  const vc = viewClause(view, {
+    currentPeriodId,
+    minReminders,
+    staleHours,
+    lookbackDays,
+    signal: view === 'needs-attention' ? signal : undefined,
+  });
   if (vc) {
     clauses.push(vc.sql);
     params.push(...vc.params);
@@ -220,23 +240,25 @@ async function search({ search, view, currentPeriodId, status, periodId, sort, d
   return { members, total };
 }
 
-async function countView(view, currentPeriodId) {
-  const vc = viewClause(view, currentPeriodId);
+async function countView(view, ctxOrPeriodId) {
+  const vc = viewClause(view, ctxOrPeriodId);
   const where = vc ? `WHERE ${vc.sql}` : '';
   const row = await db.get(`SELECT COUNT(*) as c FROM members ${where}`, ...(vc ? vc.params : []));
   return row ? row.c : 0;
 }
 
-async function countByView(currentPeriodId) {
-  const [all, active, needsRenewal, recentlyRenewed, pending, lifetime] = await Promise.all([
-    countView('all', currentPeriodId),
-    countView('active', currentPeriodId),
-    countView('needs-renewal', currentPeriodId),
-    countView('recently-renewed', currentPeriodId),
-    countView('pending', currentPeriodId),
-    countView('lifetime', currentPeriodId),
+async function countByView(ctxOrPeriodId) {
+  const ctx = normalizeViewCtx(ctxOrPeriodId);
+  const [all, active, needsRenewal, recentlyRenewed, pending, lifetime, needsAttention] = await Promise.all([
+    countView('all', ctx),
+    countView('active', ctx),
+    countView('needs-renewal', ctx),
+    countView('recently-renewed', ctx),
+    countView('pending', ctx),
+    countView('lifetime', ctx),
+    countView('needs-attention', ctx),
   ]);
-  return { all, active, needsRenewal, recentlyRenewed, pending, lifetime };
+  return { all, active, needsRenewal, recentlyRenewed, pending, lifetime, needsAttention };
 }
 
 async function listRecent(limit) {

--- a/db/repos/payments.js
+++ b/db/repos/payments.js
@@ -44,6 +44,67 @@ async function completeBySessionId(sessionId, paymentIntent) {
     return result;
 }
 
+/**
+ * Marks a still-pending checkout as failed. The `status = 'pending'` guard makes this
+ * idempotent on Stripe webhook redelivery and stops a late-arriving expiry event from
+ * clobbering a payment that actually completed.
+ */
+async function failBySessionId(sessionId, reason) {
+    const actor = getActor();
+    const old = await db.get("SELECT * FROM payments WHERE stripe_session_id = ? AND status = 'pending'", sessionId);
+    if (!old) return null;
+
+    const result = await db.run(
+        `UPDATE payments SET status = 'failed', failure_reason = ?, updated_at = datetime('now'), updated_by = ?
+     WHERE stripe_session_id = ? AND status = 'pending'`,
+        reason || null, actor.id || null, sessionId
+    );
+    const row = await db.get('SELECT * FROM payments WHERE id = ?', old.id);
+    await auditLog.insert({
+        tableName: 'payments',
+        recordId: old.id,
+        action: 'UPDATE',
+        actor,
+        oldValues: old,
+        newValues: row
+    });
+    return result;
+}
+
+/**
+ * Records a declined payment that has no pending row to update — a card failure on a
+ * PaymentIntent. Idempotent on redelivery via the payment-intent lookup.
+ */
+async function recordFailure({ member_id, stripe_payment_intent, amount_cents, reason }) {
+    const actor = getActor();
+    if (stripe_payment_intent) {
+        const existing = await db.get(
+            "SELECT id FROM payments WHERE stripe_payment_intent = ? AND status = 'failed'",
+            stripe_payment_intent
+        );
+        if (existing) return null;
+    }
+
+    const result = await db.run(
+        `INSERT INTO payments (member_id, stripe_payment_intent, amount_cents, currency, status, description,
+                               failure_reason, payment_method, created_by, updated_by)
+         VALUES (?, ?, ?, 'usd', 'failed', ?, ?, 'stripe', ?, ?)`,
+        member_id, stripe_payment_intent || null, amount_cents || 0,
+        `${new Date().getFullYear()} Membership Dues`, reason || null,
+        actor.id || null, actor.id || null
+    );
+    const row = await db.get('SELECT * FROM payments WHERE id = ?', result.lastInsertRowid);
+    await auditLog.insert({
+        tableName: 'payments',
+        recordId: result.lastInsertRowid,
+        action: 'INSERT',
+        actor,
+        oldValues: null,
+        newValues: row
+    });
+    return result;
+}
+
 async function findByMemberId(memberId) {
   return await db.all('SELECT * FROM payments WHERE member_id = ? ORDER BY created_at DESC', memberId);
 }
@@ -103,6 +164,8 @@ async function findByStripeSession(sessionId) {
 module.exports = {
   create,
   completeBySessionId,
+  failBySessionId,
+  recordFailure,
   findByMemberId,
   listWithMembers,
   listAllWithMembers,

--- a/db/schema.js
+++ b/db/schema.js
@@ -57,6 +57,7 @@ const SCHEMA = `
     currency TEXT NOT NULL DEFAULT 'usd',
     status TEXT NOT NULL DEFAULT 'pending' CHECK(status IN ('pending','completed','failed','refunded')),
     description TEXT,
+    failure_reason TEXT,
     payment_method TEXT NOT NULL DEFAULT 'stripe',
     created_at TEXT DEFAULT (datetime('now')),
     updated_at TEXT DEFAULT
@@ -350,6 +351,12 @@ const SCHEMA = `
   CREATE INDEX IF NOT EXISTS idx_campaign_visits_created ON campaign_visits(created_at);
   CREATE INDEX IF NOT EXISTS idx_contact_submissions_campaign ON contact_submissions(campaign_id);
   CREATE INDEX IF NOT EXISTS idx_contact_submissions_created ON contact_submissions(created_at);
+
+  -- Supports the "needs attention" member signals, which probe payments and emails_log
+  -- once per signal per member. See docs/needs-attention-signals.md.
+  CREATE INDEX IF NOT EXISTS idx_payments_member_status ON payments(member_id, status);
+  CREATE INDEX IF NOT EXISTS idx_emails_log_member_type ON emails_log(member_id, email_type);
+  CREATE INDEX IF NOT EXISTS idx_emails_log_status ON emails_log(status, created_at);
 `;
 
 /**

--- a/db/seed.js
+++ b/db/seed.js
@@ -121,6 +121,9 @@ async function seed() {
     contact_email: 'info@yellowstoneseahawkers.com',
     stripe_publishable_key: '',
     renewal_reminder_days_before: '30',
+    attention_reminder_count: '2',
+    attention_pending_payment_hours: '24',
+    attention_lookback_days: '180',
     social_facebook_url: '',
     social_instagram_url: '',
   };

--- a/docs/needs-attention-signals.md
+++ b/docs/needs-attention-signals.md
@@ -1,0 +1,212 @@
+# Needs-attention signals
+
+The **Needs attention** view on `/admin/members` surfaces members who look like they
+tried to join or renew and didn't finish, so the Membership Coordinator can call them.
+
+Read this before changing a threshold or adding a signal. **Every signal is a proxy, not
+a fact.** The app cannot observe intent, so each predicate infers "this person meant to
+pay and something went wrong" from database state that is also consistent with other
+explanations. The user guide is the place to describe what the badges mean to a
+coordinator; this file is about what the queries actually prove.
+
+## Where the code lives
+
+| File | Role |
+|---|---|
+| `db/repos/memberAttention.js` | The seven predicates, the OR group, and per-row attribution. Single source of truth. |
+| `services/attention.js` | Resolves settings + current period into the context the predicates bind. |
+| `db/repos/members.js` | `viewClause` delegates the `needs-attention` case; `countByView` adds the pill count. |
+| `routes/admin.js` | `view` / `signal` whitelists, badge attachment, CSV `Signals` column. |
+| `views/admin/members/list.pug` | Pill, signal `<select>`, badges. |
+
+## Who is eligible at all
+
+Before any signal is considered, `eligibilityGate` excludes members who are **cancelled**,
+**lifetime**, or **already enrolled in the current membership period**. Someone who has
+paid for the season now open does not need outreach, whatever failed for them earlier.
+
+Enrollment means a `membership_years` row for the current period. That row is written only
+by a successful payment webhook, which makes it the authoritative record of "completed this
+season" — and the only one of the three candidate definitions that survives contact with
+real data.
+
+**Two rejected definitions, both of which were actually tried:**
+
+- **`status != 'active'`** — nothing in this codebase ever writes `status = 'expired'`;
+  there is no expiry job. A lapsed member keeps `status = 'active'` with a stale
+  `expiry_date`. This would exclude precisely the people `repeated_reminders` and
+  `renewal_never_started` exist to find, turning both into dead code that quietly matches
+  nobody forever.
+- **The derived good-standing test** used by the `active` viewClause (`status='active'` and
+  `is_lifetime` / null `expiry_date` / future `expiry_date`). It reads correctly and is
+  wrong here for two independent reasons: most of the membership has a **null**
+  `expiry_date` because it predates expiry tracking, and `expiry_date` records the period a
+  member *last paid for*, so it can sit in the future while they have not paid for the
+  season now open. In production this dropped 106 of 172 active members who had genuinely
+  not renewed.
+
+Both mistakes have regression tests (`a member with no expiry date but no current
+enrollment is still eligible`, `a future expiry date does not excuse a missing current
+enrollment`, `a lapsed member still carrying status=active is eligible`).
+
+With no current period nobody can be enrolled, so the gate degrades to excluding only
+cancelled and lifetime members — a wider list rather than a silently empty one. The gate
+binds its parameter before the OR group's, which matters because `translateParams` numbers
+`$n` positionally.
+
+Note that `repeated_reminders` and `renewal_never_started` **also** carry their own
+current-period check, now partly redundant with the gate. Keep it: `signalsForIds`
+evaluates each predicate *without* the gate, so per-signal attribution depends on each
+predicate standing alone.
+
+## The signals
+
+Each is a self-contained boolean SQL predicate correlated on `members.id`, all ANDed with
+the eligibility gate above.
+
+| key | proves | does *not* prove |
+|---|---|---|
+| `repeated_reminders` | ≥ N `renewal_reminder` rows in `emails_log` and no current-period `membership_years` row. Primaries only, non-lifetime. | That they saw the emails. This is the closest thing to the "going to spam" signal, but MailerSend accepting a send is not delivery — see *No bounce data* below. |
+| `payment_failed` | A `payments` row with `status='failed'` and no `completed` row since. | Anything, unless the Stripe failure webhooks are subscribed. See *Deploy coupling*. |
+| `stale_pending_payment` | A `pending` payment older than the threshold with no `completed` row since. | That the card was declined. Closing the tab looks identical. |
+| `pending_no_payment` | A `pending` member older than the threshold with zero `payments` rows. | Which of the two causes applied: `createCheckoutSession` threw, or they abandoned the form before submitting. |
+| `duplicate_pending` | Two `pending` primaries sharing an email, case-insensitively. | Which row is canonical. Merge before calling. |
+| `email_send_failed` | An `emails_log` row with `status='failed'` and no successful send to the same address since. Matched on `to_email` as well as `member_id`, because `otp` and `contact` rows carry a null `member_id` — see the two guards below. | That the address is permanently bad, only that the last attempt failed. |
+| `renewal_never_started` | Unexpired `renewal_token`, `expiry_date` already past, fewer than N reminders, no current-period enrollment. | That they never clicked the link — see below. |
+
+### Why `renewal_never_started` is gated the way it is
+
+The obvious version of this signal — "has an unexpired `renewal_token` and hasn't
+renewed" — is useless. `services/renewal.js:generateRenewalToken` **re-extends
+`renewal_token_expires_at` on every send**, so an unexpired token is true for everyone
+who has ever received a single reminder. That predicate would return the entire
+needs-renewal population.
+
+Two gates make it meaningful:
+
+- `expiry_date < today` — they are actually lapsed, not merely approaching renewal. That
+  is what distinguishes this from the existing **Needs renewal** pill.
+- reminder count `< minReminders` — the strict complement of `repeated_reminders`, so
+  the two signals partition the population instead of double-badging the same people.
+
+There is also no "token consumed" flag anywhere: `findByRenewalToken` checks only
+expiry, and the token is cleared only by a successful webhook. So a member who opened
+the renewal page and bailed at Stripe is indistinguishable from one who never clicked —
+except that `POST /renew/:token` creates a `pending` payment row, which trips
+`stale_pending_payment` instead. That is the intended division of labor.
+
+## Two passes, and why
+
+`attentionClause(ctx)` builds the OR group for filtering. `signalsForIds(ids, ctx)` then
+re-evaluates each predicate individually over just the returned ids to produce badges.
+
+The obvious alternative — adding `CASE WHEN <predicate> THEN 1 ELSE 0 END` columns to
+`members.search()` — does not work. `search()` builds **one** param array and binds it
+to both its `COUNT(*)` query and its `SELECT` query. Select-list params would be present
+in one and absent from the other, so the count would desync from the rows.
+
+Reusing the same predicate *text* for both passes is what guarantees a badge can never
+disagree with the filter that selected the row. `test/repos/memberAttention.test.js` has
+a test asserting exactly that: every row the filter returns has at least one badge.
+
+## Dialect rules
+
+These queries run under both better-sqlite3 and PostgreSQL, and `db/pg-translate.js`
+translates far less than it looks like it does. It handles only `datetime('now')`,
+`date('now')`, one specific `date('now', '+' || ? || ' days')` shape,
+`strftime(..., 'now')`, `INSERT OR IGNORE`, and `?` → `$n`.
+
+So:
+
+- **All date boundaries are computed in JS and bound as parameters.** `created_at` and
+  `expiry_date` are TEXT columns; comparing them to a SQL date function fails on
+  PostgreSQL with a text-vs-date type error. This is what caused the PR #69 revert.
+- **`CASE WHEN ... THEN 1 ELSE 0 END`, never a bare `EXISTS`, in a select list.** `EXISTS`
+  returns a PostgreSQL boolean and a SQLite integer, and that difference leaks into the
+  CSV export as `true` vs `1`.
+- **No `GROUP_CONCAT`.** There is no `string_agg` translation, which is a second reason
+  the signal list is assembled in JS rather than SQL.
+- **No `strftime` with non-`'now'` arguments, no `julianday`, no `IFNULL`, no boolean
+  literals.**
+- The `IN (...)` list in `signalsForIds` is chunked at 400 ids because the CSV export
+  path runs unlimited and SQLite caps a statement at 999 bound parameters. The predicate
+  params ride along on every chunk, so the real budget is smaller than it looks.
+
+Jest runs in-memory SQLite and Robot runs a SQLite file, so **neither test layer
+exercises `pg-translate`**. Verify PostgreSQL manually against Render before shipping
+changes here.
+
+## Settings
+
+Read by `services/attention.js`, with fallbacks if unset or non-numeric:
+
+| key | default | effect |
+|---|---|---|
+| `attention_reminder_count` | 2 | Reminders before flagging. Lowering widens the list. Also raises the `renewal_never_started` ceiling, since the two partition on this value. |
+| `attention_pending_payment_hours` | 24 | Grace period before an unfinished checkout counts as abandoned. |
+| `attention_lookback_days` | 180 | Bounds every signal, so the list is an outreach queue rather than the club's full history. |
+
+## Deploy coupling
+
+`payment_failed` has **no data source** unless `checkout.session.expired` and
+`payment_intent.payment_failed` are subscribed on the Stripe webhook endpoint. Before
+this feature, `payments.status` allowed `'failed'` but no code path ever wrote it.
+
+`services/stripe.js` also sets `payment_intent_data: { metadata }` on session creation.
+Without it a `payment_intent.payment_failed` event cannot be traced to a member, because
+the event carries the PaymentIntent rather than the checkout session. Payments created
+before that change will log a warning and no-op.
+
+## Why `email_send_failed` has two extra guards
+
+Both were added after the naive version misfired on production data, and both have
+regression tests. Do not simplify this predicate without re-reading this section.
+
+**1. The `to_email` fallback is restricted to primaries.** The fallback exists because
+`otp` and `contact` rows carry a null `member_id`. But family sub-members share the
+primary's email address, so an unattributed failure matched *every* member of the family.
+The original production symptom was a primary plus three sub-members all badged from two
+`card_delivery` failures against one address. Adding `members.primary_member_id IS NULL` to
+the fallback branch flags the one person you would actually call. A sub-member whose own
+send failed still matches on `e.member_id`, which is precise and needs no such guard.
+
+**2. A later success to the same address clears the failure.** `payment_failed` suppresses
+itself once a payment completes; this now does the same via a nested `NOT EXISTS` for a
+`sent` row with `created_at > e.created_at` for the same address. Without it, one
+account-level provider problem badges members for the whole lookback window even though
+every send since has worked — the production failures were all
+`Your trial domain reached its email quota limit. #MS42222`, which said nothing about the
+members it flagged.
+
+The recovery check matches on **address**, not `member_id`, because deliverability is a
+property of the address. A later success to a different address proves nothing about this
+one, and a success recorded with a null `member_id` still counts. Note the ordering
+consequence: a success *before* the failure does not excuse it, so a member whose mail
+worked and then broke stays flagged.
+
+## No bounce data
+
+`email_send_failed` catches only sends **MailerSend rejected outright**, recorded when
+`services/email.js` writes `status='failed'`. There is no MailerSend webhook in this
+app, so a message that was accepted and then bounced, or was delivered into a spam
+folder, is invisible. That is why the badge reads "Email send failed" rather than
+"bounced" — do not relabel it without adding the webhook first.
+
+Adding a MailerSend webhook is the highest-value extension here, since suspected spam
+filtering is the Coordinator's actual concern and `repeated_reminders` is only a proxy
+for it.
+
+## Deliberately excluded
+
+Two signals were designed and left out. They are real problems — `routes/stripe.js`
+swallows the relevant errors into `logger.error` — but they describe **data to repair**
+rather than **people to call**, and on day one they would return a historical backlog
+that buries the outreach list:
+
+- **Completed payment with no current-period `membership_years` row** — the enroll block
+  at `routes/stripe.js:43-67` failed. The member paid and is not enrolled.
+- **Enrolled with no `membership_cards` row for the year** — card generation at
+  `routes/stripe.js:79-92` failed. The member paid and has no card.
+
+If these are added later, put them behind their own filter or admin report rather than
+folding them into this pill.

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -310,6 +310,18 @@ a.stat-card:hover {
   margin-left: 0.4rem;
 }
 
+/* Needs-attention signals. A member can trip several at once, so these wrap and
+   keep their own spacing rather than relying on whitespace in the template. */
+.badge-attention {
+  background: #ffe8cc;
+  color: #8a4b00;
+  border: 1px solid #ffd8a8;
+  text-transform: none;
+  font-size: 0.75rem;
+  padding: 0.25rem 0.6rem;
+  margin: 0 0.3rem 0.3rem 0;
+}
+
 /* === Toolbar === */
 .admin-toolbar {
   display: flex;

--- a/robot/libraries/DatabaseManager.py
+++ b/robot/libraries/DatabaseManager.py
@@ -1,5 +1,6 @@
 import sqlite3
 import os
+from datetime import datetime, timedelta
 
 
 class DatabaseManager:
@@ -203,7 +204,8 @@ class DatabaseManager:
     def seed_member(self, first_name='Test', last_name='Member', email=None,
                     phone=None, status='active', membership_year=2026,
                     member_number=None, address_street=None, address_city=None,
-                    address_state='MT', address_zip=None, notes=None):
+                    address_state='MT', address_zip=None, notes=None,
+                    expiry_date=None):
         """Insert a member and return the row ID."""
         if email is None:
             import random
@@ -215,11 +217,53 @@ class DatabaseManager:
             '''INSERT INTO members
                (member_number, first_name, last_name, email, phone,
                 address_street, address_city, address_state, address_zip,
-                membership_year, status, notes)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+                membership_year, status, notes, expiry_date)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
             (member_number, first_name, last_name, email, phone,
              address_street, address_city, address_state, address_zip,
-             membership_year, status, notes),
+             membership_year, status, notes, expiry_date),
+        )
+        self.conn.commit()
+        return cursor.lastrowid
+
+    def seed_payment(self, member_id, status='completed', amount_cents=1600,
+                     stripe_session_id=None, stripe_payment_intent=None,
+                     failure_reason=None, hours_ago=None):
+        """Insert a payment and return the row ID.
+
+        `hours_ago` backdates created_at, which is how a test makes a pending payment
+        old enough to count as an abandoned checkout.
+        """
+        if hours_ago is None:
+            created_at = datetime.utcnow()
+        else:
+            created_at = datetime.utcnow() - timedelta(hours=float(hours_ago))
+        cursor = self.conn.execute(
+            '''INSERT INTO payments
+               (member_id, amount_cents, currency, status, description, payment_method,
+                stripe_session_id, stripe_payment_intent, failure_reason, created_at)
+               VALUES (?, ?, 'usd', ?, 'Robot test payment', 'stripe', ?, ?, ?, ?)''',
+            (int(member_id), int(amount_cents), status, stripe_session_id,
+             stripe_payment_intent, failure_reason,
+             created_at.strftime('%Y-%m-%d %H:%M:%S')),
+        )
+        self.conn.commit()
+        return cursor.lastrowid
+
+    def seed_email_log(self, member_id=None, email_type='renewal_reminder',
+                       status='sent', to_email='robot@example.com', days_ago=None):
+        """Insert an emails_log row and return the row ID."""
+        if days_ago is None:
+            created_at = datetime.utcnow()
+        else:
+            created_at = datetime.utcnow() - timedelta(days=float(days_ago))
+        cursor = self.conn.execute(
+            '''INSERT INTO emails_log
+               (to_email, to_name, subject, email_type, status, member_id, created_at)
+               VALUES (?, 'Robot Test', 'Robot test email', ?, ?, ?, ?)''',
+            (to_email, email_type, status,
+             int(member_id) if member_id is not None else None,
+             created_at.strftime('%Y-%m-%d %H:%M:%S')),
         )
         self.conn.commit()
         return cursor.lastrowid

--- a/robot/tests/admin_members.robot
+++ b/robot/tests/admin_members.robot
@@ -78,3 +78,54 @@ Edit Member Updates Fields
     Submit Admin Form
     Flash Success Should Be Visible    updated
     Get Text    .detail-table    contains    After Edit
+
+Needs Attention Pill Filters The List
+    [Documentation]    Drives the pill itself rather than navigating to ?view=needs-attention,
+    ...    because a URL-only test passes even when the pill is broken.
+    ${flagged}=    Seed Member    first_name=Dana    last_name=Declined    email=declined@example.com    status=pending
+    Seed Payment    ${flagged}    status=failed
+    ${clean}=    Seed Member    first_name=Casey    last_name=Clean    email=clean@example.com    status=active
+    ${period}=    Get Current Period Id
+    Enroll Member    ${clean}    ${period}
+    Seed Payment    ${clean}    status=completed
+    Login As Admin
+    Navigate To    /admin/members
+    Click    .view-pill >> text=Needs attention
+    Wait For Elements State    .admin-table    visible    timeout=10s
+    Get Text    .admin-table    contains    Dana Declined
+    Get Text    .badge-attention    contains    Payment failed
+    ${page_text}=    Get Text    .admin-table
+    Should Not Contain    ${page_text}    Casey Clean
+
+Needs Attention Signal Select Auto Submits
+    [Documentation]    Changes the select and asserts the table updated with NO further
+    ...    click. helmet sends script-src-attr 'none', so an inline onchange would never
+    ...    fire and would fail silently — this is the regression guard for that.
+    ${declined}=    Seed Member    first_name=Dana    last_name=Declined    email=declined@example.com    status=pending
+    Seed Payment    ${declined}    status=failed
+    # Lapsed rather than paid up — members in good standing are excluded from the list.
+    ${bounced}=    Seed Member    first_name=Boris    last_name=Bounced    email=bounced@example.com    status=active    expiry_date=2020-01-01
+    Seed Email Log    ${bounced}    email_type=card_delivery    status=failed
+    Login As Admin
+    Navigate To    /admin/members
+    Click    .view-pill >> text=Needs attention
+    Wait For Elements State    select[name="signal"]    visible    timeout=10s
+    Get Text    .admin-table    contains    Boris Bounced
+    Select Options By    select[name="signal"]    value    payment_failed
+    Wait For Elements State    .admin-table    visible    timeout=10s
+    Get Text    .admin-table    contains    Dana Declined
+    ${page_text}=    Get Text    .admin-table
+    Should Not Contain    ${page_text}    Boris Bounced
+
+Needs Attention Export Includes Signals
+    ${flagged}=    Seed Member    first_name=Dana    last_name=Declined    email=declined@example.com    status=pending
+    Seed Payment    ${flagged}    status=failed
+    Login As Admin
+    Navigate To    /admin/members
+    Click    .view-pill >> text=Needs attention
+    Wait For Elements State    .admin-table    visible    timeout=10s
+    ${path}=    Download Via Click    .toolbar-actions a.btn-outline    filename=members.csv
+    ${csv}=    Get File    ${path}
+    Should Contain    ${csv}    Signals
+    Should Contain    ${csv}    Stripe reported a failed payment
+    Should Contain    ${csv}    declined@example.com

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -22,6 +22,8 @@ const campaignsRepo = require('../db/repos/campaigns');
 const campaignVisitsRepo = require('../db/repos/campaignVisits');
 const contactSubmissionsRepo = require('../db/repos/contactSubmissions');
 const campaignsService = require('../services/campaigns');
+const attentionService = require('../services/attention');
+const memberAttentionRepo = require('../db/repos/memberAttention');
 const councilReport = require('../services/councilReport');
 const logger = require('../services/logger');
 const isDevOrTest = ['development', 'test', 'dev'].includes(process.env.NODE_ENV);
@@ -158,9 +160,10 @@ router.get('/dashboard', async (req, res, next) => {
 });
 
 // --- Members CRUD ---
-const MEMBER_VIEWS = ['all', 'active', 'needs-renewal', 'recently-renewed', 'pending', 'lifetime'];
+const MEMBER_VIEWS = ['all', 'active', 'needs-renewal', 'recently-renewed', 'pending', 'lifetime', 'needs-attention'];
 const MEMBER_SORTS = ['member_number', 'name', 'email', 'year', 'status', 'created_at'];
 const MEMBER_STATUSES = ['active', 'expired', 'pending', 'cancelled'];
+const MEMBER_SIGNALS = attentionService.SIGNAL_KEYS;
 
 function parseMemberListQuery(req) {
   return {
@@ -170,6 +173,7 @@ function parseMemberListQuery(req) {
     search: req.query.search || '',
     status: MEMBER_STATUSES.includes(req.query.status) ? req.query.status : '',
     periodId: parseInt(req.query.period) || null,
+    signal: MEMBER_SIGNALS.includes(req.query.signal) ? req.query.signal : '',
   };
 }
 
@@ -180,11 +184,24 @@ function memberListQs(state, overrides = {}) {
   if (q.search) params.set('search', q.search);
   if (q.status) params.set('status', q.status);
   if (q.period) params.set('period', q.period);
+  if (q.signal) params.set('signal', q.signal);
   if (q.sort && q.sort !== 'created_at') params.set('sort', q.sort);
   if (q.dir && q.dir !== 'desc') params.set('dir', q.dir);
   if (q.page && q.page > 1) params.set('page', q.page);
   const s = params.toString();
   return s ? `?${s}` : '';
+}
+
+/**
+ * Attaches the list of signals that fired to each member, for badges and CSV.
+ * Only meaningful under the needs-attention view.
+ */
+async function attachAttentionSignals(members, attentionCtx) {
+  if (!members.length) return;
+  const byId = await memberAttentionRepo.signalsForIds(members.map(m => m.id), attentionCtx);
+  for (const member of members) {
+    member.attention_signals = byId.get(member.id) || [];
+  }
 }
 
 router.get('/members', async (req, res, next) => {
@@ -194,21 +211,27 @@ router.get('/members', async (req, res, next) => {
     const offset = (page - 1) * limit;
     const parsed = parseMemberListQuery(req);
 
-    const currentPeriod = await periodsRepo.getCurrent();
-    const currentPeriodId = currentPeriod ? currentPeriod.id : null;
+    // The attention context carries the current period as well as the thresholds, so
+    // it doubles as the view context for every other view.
+    const attentionCtx = await attentionService.buildContext();
     const [{ members, total }, counts, periods] = await Promise.all([
-      memberRepo.search({ ...parsed, currentPeriodId, limit, offset }),
-      memberRepo.countByView(currentPeriodId),
+      memberRepo.search({ ...parsed, ...attentionCtx, limit, offset }),
+      memberRepo.countByView(attentionCtx),
       periodsRepo.list(),
     ]);
     const totalPages = Math.ceil(total / limit);
 
-    const { view, sort, dir, search, status, periodId } = parsed;
+    const { view, sort, dir, search, status, periodId, signal } = parsed;
+    if (view === 'needs-attention') {
+      await attachAttentionSignals(members, { ...attentionCtx, signal });
+    }
+
     res.render('admin/members/list', {
       members, page, totalPages, total,
-      view, sort, dir, search, status, periodId,
+      view, sort, dir, search, status, periodId, signal,
       counts, periods,
-      qs: (overrides) => memberListQs({ view, search, status, period: periodId, sort, dir }, overrides),
+      signalOptions: attentionService.SIGNAL_LABELS,
+      qs: (overrides) => memberListQs({ view, search, status, period: periodId, signal, sort, dir }, overrides),
     });
   } catch (err) {
     next(err);
@@ -219,10 +242,22 @@ router.get('/members/export', async (req, res, next) => {
   try {
     const { toCsv } = require('../services/csv');
     const parsed = parseMemberListQuery(req);
-    const currentPeriod = await periodsRepo.getCurrent();
-    const { members } = await memberRepo.search({ ...parsed, currentPeriodId: currentPeriod ? currentPeriod.id : null });
+    const attentionCtx = await attentionService.buildContext();
+    const { members } = await memberRepo.search({ ...parsed, ...attentionCtx });
     const columns = ['member_number', 'first_name', 'last_name', 'email', 'phone', 'address_street', 'address_city', 'address_state', 'address_zip', 'membership_year', 'status', 'notes', 'created_at'];
     const headers = ['Member Number', 'First Name', 'Last Name', 'Email', 'Phone', 'Street', 'City', 'State', 'Zip', 'Year', 'Status', 'Notes', 'Created'];
+
+    // The whole point of this export is the outreach call list, so the signals have to
+    // travel with it — a row without them tells the Coordinator nothing about why.
+    if (parsed.view === 'needs-attention') {
+      await attachAttentionSignals(members, { ...attentionCtx, signal: parsed.signal });
+      for (const member of members) {
+        member.attention_signal_labels = member.attention_signals.map(s => s.label).join('; ');
+      }
+      columns.push('attention_signal_labels');
+      headers.push('Signals');
+    }
+
     const csv = toCsv(members, columns, headers);
     const date = new Date().toISOString().slice(0, 10);
     const viewPart = parsed.view !== 'all' ? `${parsed.view}-` : '';
@@ -1182,6 +1217,7 @@ router.post('/settings', requireSuperAdmin, async (req, res) => {
     'gallery_album_url',
     'contact_email', 'stripe_publishable_key',
     'renewal_reminder_days_before',
+    'attention_reminder_count', 'attention_pending_payment_hours', 'attention_lookback_days',
     'social_facebook_url', 'social_instagram_url',
   ];
   const keyValues = {};

--- a/routes/stripe.js
+++ b/routes/stripe.js
@@ -114,6 +114,33 @@ router.post('/webhook', async (req, res) => {
         logger.error('Email send error', { error: e.message, stack: e.stack });
       }
     }
+  } else if (event.type === 'checkout.session.expired') {
+    // Abandoned checkout. Wrapped so a DB error still returns 2xx — Stripe retries on
+    // anything else, and this is not worth a retry storm.
+    const session = event.data.object;
+    try {
+      await paymentsService.expireStripeCheckout(session.id, 'Checkout session expired');
+    } catch (e) {
+      logger.error('Error recording expired checkout', { error: e.message, sessionId: session.id });
+    }
+  } else if (event.type === 'payment_intent.payment_failed') {
+    const intent = event.data.object;
+    const memberId = intent.metadata?.member_id;
+    if (!memberId) {
+      // Pre-dates payment_intent_data.metadata, or an intent we did not create.
+      logger.warn('Payment failure with no member_id metadata', { paymentIntent: intent.id });
+    } else {
+      try {
+        await paymentsService.recordStripeFailure({
+          memberId,
+          paymentIntent: intent.id,
+          amountCents: intent.amount,
+          reason: intent.last_payment_error?.message || 'Payment failed',
+        });
+      } catch (e) {
+        logger.error('Error recording payment failure', { error: e.message, paymentIntent: intent.id });
+      }
+    }
   }
 
   res.json({ received: true });

--- a/services/attention.js
+++ b/services/attention.js
@@ -1,0 +1,44 @@
+const settingsRepo = require('../db/repos/settings');
+const periodsRepo = require('../db/repos/membershipPeriods');
+const { SIGNAL_KEYS, SIGNAL_LABELS } = require('../db/repos/memberAttention');
+
+const DEFAULTS = {
+  attention_reminder_count: 2,
+  attention_pending_payment_hours: 24,
+  attention_lookback_days: 180,
+};
+
+function toInt(value, fallback) {
+  const n = parseInt(value);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+/**
+ * Resolves the tunables and current period the needs-attention predicates need.
+ *
+ * Lives in the service layer so the repo stays settings-free and unit-testable with
+ * plain numbers, the same split services/renewal.js uses for
+ * renewal_reminder_days_before.
+ */
+async function buildContext() {
+  const [period, reminderCount, staleHours, lookbackDays] = await Promise.all([
+    periodsRepo.getCurrent(),
+    settingsRepo.get('attention_reminder_count'),
+    settingsRepo.get('attention_pending_payment_hours'),
+    settingsRepo.get('attention_lookback_days'),
+  ]);
+
+  return {
+    currentPeriodId: period ? period.id : null,
+    minReminders: toInt(reminderCount, DEFAULTS.attention_reminder_count),
+    staleHours: toInt(staleHours, DEFAULTS.attention_pending_payment_hours),
+    lookbackDays: toInt(lookbackDays, DEFAULTS.attention_lookback_days),
+  };
+}
+
+module.exports = {
+  DEFAULTS,
+  SIGNAL_KEYS,
+  SIGNAL_LABELS,
+  buildContext,
+};

--- a/services/payments.js
+++ b/services/payments.js
@@ -20,7 +20,30 @@ async function completeStripePayment(sessionId, paymentIntent) {
   await paymentRepo.completeBySessionId(sessionId, paymentIntent);
 }
 
+/**
+ * A checkout session expired without being paid — the member opened Stripe and walked
+ * away. Flips the pending row so the Needs attention filter can surface them.
+ */
+async function expireStripeCheckout(sessionId, reason) {
+  await paymentRepo.failBySessionId(sessionId, reason || 'Checkout session expired');
+}
+
+/**
+ * A card was declined. Recorded as its own row rather than as an update, because the
+ * member may retry successfully afterwards and both attempts are worth keeping.
+ */
+async function recordStripeFailure({ memberId, paymentIntent, amountCents, reason }) {
+  await paymentRepo.recordFailure({
+    member_id: memberId,
+    stripe_payment_intent: paymentIntent,
+    amount_cents: amountCents,
+    reason,
+  });
+}
+
 module.exports = {
   recordOfflinePayment,
   completeStripePayment,
+  expireStripeCheckout,
+  recordStripeFailure,
 };

--- a/services/stripe.js
+++ b/services/stripe.js
@@ -57,6 +57,10 @@ async function createCheckoutSession({
         payment_method_types: ['card'],
         customer_email: email,
         metadata,
+        // Copy the metadata onto the PaymentIntent as well. A
+        // payment_intent.payment_failed event carries the intent, not the session, so
+        // without this a declined card cannot be traced back to a member.
+        payment_intent_data: {metadata},
         line_items: lineItems,
     mode: 'payment',
     success_url: `${baseUrl}/membership/success?session_id={CHECKOUT_SESSION_ID}`,

--- a/test/helpers/fixtures.js
+++ b/test/helpers/fixtures.js
@@ -17,14 +17,16 @@ function buildMember(overrides = {}) {
 function insertMember(db, overrides = {}) {
   const m = buildMember(overrides);
   const info = db.prepare(
-    `INSERT INTO members (first_name, last_name, email, phone, address_street, address_city, address_state, address_zip, membership_year, status, member_number, membership_type, primary_member_id, expiry_date, is_lifetime)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    `INSERT INTO members (first_name, last_name, email, phone, address_street, address_city, address_state, address_zip, membership_year, status, member_number, membership_type, primary_member_id, expiry_date, is_lifetime, renewal_token, renewal_token_expires_at, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')))`
   ).run(
     m.first_name, m.last_name, m.email, m.phone,
     m.address_street, m.address_city, m.address_state, m.address_zip,
     m.membership_year, m.status, m.member_number || null,
     m.membership_type || 'individual', m.primary_member_id || null,
-    m.expiry_date || null, m.is_lifetime ? 1 : 0
+    m.expiry_date || null, m.is_lifetime ? 1 : 0,
+    m.renewal_token || null, m.renewal_token_expires_at || null,
+    m.created_at || null
   );
   return { ...m, id: info.lastInsertRowid };
 }
@@ -80,11 +82,30 @@ function insertPayment(db, overrides = {}) {
     stripe_session_id: overrides.stripe_session_id || null,
     stripe_payment_intent: overrides.stripe_payment_intent || null,
   };
+  // created_at is overridable so a test can make a payment old enough to count as an
+  // abandoned checkout.
   const info = db.prepare(
-    `INSERT INTO payments (member_id, amount_cents, currency, status, description, payment_method, stripe_session_id, stripe_payment_intent)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
-  ).run(p.member_id, p.amount_cents, p.currency, p.status, p.description, p.payment_method, p.stripe_session_id, p.stripe_payment_intent);
-  return { ...p, id: info.lastInsertRowid };
+    `INSERT INTO payments (member_id, amount_cents, currency, status, description, payment_method, stripe_session_id, stripe_payment_intent, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')))`
+  ).run(p.member_id, p.amount_cents, p.currency, p.status, p.description, p.payment_method, p.stripe_session_id, p.stripe_payment_intent, overrides.created_at || null);
+  return { ...p, created_at: overrides.created_at || null, id: info.lastInsertRowid };
+}
+
+function insertEmailLog(db, overrides = {}) {
+  const e = {
+    to_email: overrides.to_email || 'jane@example.com',
+    to_name: overrides.to_name || 'Jane Doe',
+    subject: overrides.subject || 'Test subject',
+    email_type: overrides.email_type || 'renewal_reminder',
+    status: overrides.status || 'sent',
+    error: overrides.error || null,
+    member_id: overrides.member_id ?? null,
+  };
+  const info = db.prepare(
+    `INSERT INTO emails_log (to_email, to_name, subject, email_type, status, error, member_id, created_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, COALESCE(?, datetime('now')))`
+  ).run(e.to_email, e.to_name, e.subject, e.email_type, e.status, e.error, e.member_id, overrides.created_at || null);
+  return { ...e, id: info.lastInsertRowid };
 }
 
 function buildFamilyMembership(overrides = {}) {
@@ -214,6 +235,7 @@ module.exports = {
     buildAdmin,
     insertAdmin,
     insertPayment,
+    insertEmailLog,
     buildFamilyMembership,
     insertFamilyMembership,
     insertPeriod,

--- a/test/repos/memberAttention.test.js
+++ b/test/repos/memberAttention.test.js
@@ -1,0 +1,522 @@
+jest.mock('../../db/database', () => require('../helpers/setupDb'));
+
+const db = require('../../db/database');
+const memberRepo = require('../../db/repos/members');
+const memberAttention = require('../../db/repos/memberAttention');
+const {
+  insertMember, insertPayment, insertEmailLog, insertPeriod, enrollMember,
+} = require('../helpers/fixtures');
+
+function isoDate(offsetDays = 0) {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+}
+
+// Old enough to be past the default 24h unfinished-checkout threshold.
+function hoursAgo(hours) {
+  return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString().slice(0, 19).replace('T', ' ');
+}
+
+function isoIn(days) {
+  return new Date(Date.now() + days * 24 * 60 * 60 * 1000).toISOString();
+}
+
+beforeEach(() => {
+  db.__resetTestDb();
+});
+
+/** Emails of the members the needs-attention view returns, sorted. */
+async function attentionEmails(overrides = {}) {
+  const { members } = await memberRepo.search({ view: 'needs-attention', ...overrides });
+  return members.map(m => m.email).sort();
+}
+
+describe('needs-attention signals', () => {
+  test('repeated_reminders flags a member reminded twice who never renewed', async () => {
+    const testDb = db.__getCurrentDb();
+    const period = insertPeriod(testDb);
+    const stuck = insertMember(testDb, { email: 'stuck@t.com', status: 'active', expiry_date: isoDate(-5) });
+    insertEmailLog(testDb, { member_id: stuck.id, email_type: 'renewal_reminder' });
+    insertEmailLog(testDb, { member_id: stuck.id, email_type: 'renewal_reminder' });
+
+    // Same two reminders, but they did renew.
+    const renewed = insertMember(testDb, { email: 'renewed@t.com', status: 'active', expiry_date: isoDate(-5) });
+    insertEmailLog(testDb, { member_id: renewed.id, email_type: 'renewal_reminder' });
+    insertEmailLog(testDb, { member_id: renewed.id, email_type: 'renewal_reminder' });
+    enrollMember(testDb, renewed.id, period.id);
+
+    expect(await attentionEmails({ currentPeriodId: period.id })).toEqual(['stuck@t.com']);
+  });
+
+  test('repeated_reminders respects the reminder threshold', async () => {
+    const testDb = db.__getCurrentDb();
+    const period = insertPeriod(testDb);
+    const m = insertMember(testDb, { email: 'once@t.com', status: 'active', expiry_date: isoDate(-5) });
+    insertEmailLog(testDb, { member_id: m.id, email_type: 'renewal_reminder' });
+
+    // One reminder is below the default of 2.
+    const ctx = { currentPeriodId: period.id };
+    expect(await attentionEmails({ ...ctx, signal: 'repeated_reminders' })).toEqual([]);
+    // Threshold of 1 catches them.
+    expect(await attentionEmails({ ...ctx, signal: 'repeated_reminders', minReminders: 1 })).toEqual(['once@t.com']);
+  });
+
+  test('repeated_reminders ignores reminders older than the lookback window', async () => {
+    const testDb = db.__getCurrentDb();
+    const period = insertPeriod(testDb);
+    const m = insertMember(testDb, { email: 'ancient@t.com', status: 'active', expiry_date: isoDate(-5) });
+    insertEmailLog(testDb, { member_id: m.id, email_type: 'renewal_reminder', created_at: `${isoDate(-400)} 12:00:00` });
+    insertEmailLog(testDb, { member_id: m.id, email_type: 'renewal_reminder', created_at: `${isoDate(-400)} 12:05:00` });
+
+    expect(await attentionEmails({
+      currentPeriodId: period.id, signal: 'repeated_reminders', lookbackDays: 180,
+    })).toEqual([]);
+  });
+
+  test('repeated_reminders ignores non-renewal email types', async () => {
+    const testDb = db.__getCurrentDb();
+    const period = insertPeriod(testDb);
+    const m = insertMember(testDb, { email: 'blasted@t.com', status: 'active', expiry_date: isoDate(-5) });
+    insertEmailLog(testDb, { member_id: m.id, email_type: 'blast' });
+    insertEmailLog(testDb, { member_id: m.id, email_type: 'blast' });
+
+    expect(await attentionEmails({ currentPeriodId: period.id, signal: 'repeated_reminders' })).toEqual([]);
+  });
+
+  test('payment_failed flags a declined payment with no later success', async () => {
+    const testDb = db.__getCurrentDb();
+    const declined = insertMember(testDb, { email: 'declined@t.com', status: 'pending' });
+    insertPayment(testDb, { member_id: declined.id, status: 'failed' });
+
+    // Failed then retried successfully — not a problem any more.
+    const retried = insertMember(testDb, { email: 'retried@t.com', status: 'active' });
+    insertPayment(testDb, { member_id: retried.id, status: 'failed' });
+    insertPayment(testDb, { member_id: retried.id, status: 'completed' });
+
+    expect(await attentionEmails({ signal: 'payment_failed' })).toEqual(['declined@t.com']);
+  });
+
+  test('payment_failed works with no current period', async () => {
+    const testDb = db.__getCurrentDb();
+    const m = insertMember(testDb, { email: 'noperiod@t.com', status: 'pending' });
+    insertPayment(testDb, { member_id: m.id, status: 'failed' });
+
+    expect(await attentionEmails({ currentPeriodId: null })).toEqual(['noperiod@t.com']);
+  });
+
+  test('stale_pending_payment flags an old pending payment but not a fresh one', async () => {
+    const testDb = db.__getCurrentDb();
+    const abandoned = insertMember(testDb, { email: 'abandoned@t.com', status: 'pending' });
+    insertPayment(testDb, { member_id: abandoned.id, status: 'pending', created_at: hoursAgo(48) });
+
+    // Still at the Stripe form right now.
+    const inFlight = insertMember(testDb, { email: 'inflight@t.com', status: 'pending' });
+    insertPayment(testDb, { member_id: inFlight.id, status: 'pending' });
+
+    expect(await attentionEmails({ signal: 'stale_pending_payment' })).toEqual(['abandoned@t.com']);
+  });
+
+  test('stale_pending_payment honors the staleHours threshold', async () => {
+    const testDb = db.__getCurrentDb();
+    const m = insertMember(testDb, { email: 'recent@t.com', status: 'pending' });
+    insertPayment(testDb, { member_id: m.id, status: 'pending', created_at: hoursAgo(3) });
+
+    expect(await attentionEmails({ signal: 'stale_pending_payment', staleHours: 24 })).toEqual([]);
+    expect(await attentionEmails({ signal: 'stale_pending_payment', staleHours: 1 })).toEqual(['recent@t.com']);
+  });
+
+  test('pending_no_payment flags an old pending signup with no payment rows', async () => {
+    const testDb = db.__getCurrentDb();
+    insertMember(testDb, { email: 'nostripe@t.com', status: 'pending', created_at: hoursAgo(48) });
+
+    // Just signed up — still mid-flow, not a problem yet.
+    insertMember(testDb, { email: 'justnow@t.com', status: 'pending' });
+
+    // Old pending signup that did reach Stripe is a different signal.
+    const reached = insertMember(testDb, { email: 'reached@t.com', status: 'pending', created_at: hoursAgo(48) });
+    insertPayment(testDb, { member_id: reached.id, status: 'pending' });
+
+    expect(await attentionEmails({ signal: 'pending_no_payment' })).toEqual(['nostripe@t.com']);
+  });
+
+  test('duplicate_pending flags pending duplicates, matching case-insensitively', async () => {
+    const testDb = db.__getCurrentDb();
+    insertMember(testDb, { email: 'dupe@t.com', status: 'pending' });
+    insertMember(testDb, { email: 'DUPE@t.com', status: 'pending' });
+    insertMember(testDb, { email: 'unique@t.com', status: 'pending' });
+
+    expect(await attentionEmails({ signal: 'duplicate_pending' })).toEqual(['DUPE@t.com', 'dupe@t.com']);
+  });
+
+  test('email_send_failed flags a member whose email could not be sent', async () => {
+    const testDb = db.__getCurrentDb();
+    // Lapsed, not paid up — a paid-up member is excluded by the eligibility gate no
+    // matter what failed, so this signal is only ever about people we still need.
+    const bounced = insertMember(testDb, { email: 'bounced@t.com', status: 'active', expiry_date: isoDate(-5) });
+    insertEmailLog(testDb, { member_id: bounced.id, email_type: 'card_delivery', status: 'failed' });
+
+    const fine = insertMember(testDb, { email: 'fine@t.com', status: 'active', expiry_date: isoDate(-5) });
+    insertEmailLog(testDb, { member_id: fine.id, email_type: 'card_delivery', status: 'sent' });
+
+    expect(await attentionEmails({ signal: 'email_send_failed' })).toEqual(['bounced@t.com']);
+  });
+
+  test('email_send_failed matches rows logged without a member_id via to_email', async () => {
+    const testDb = db.__getCurrentDb();
+    insertMember(testDb, { email: 'orphan@t.com', status: 'active', expiry_date: isoDate(-5) });
+    // otp and contact emails are logged with a null member_id.
+    insertEmailLog(testDb, { member_id: null, to_email: 'ORPHAN@t.com', email_type: 'otp', status: 'failed' });
+
+    expect(await attentionEmails({ signal: 'email_send_failed' })).toEqual(['orphan@t.com']);
+  });
+
+  test('email_send_failed flags only the primary when a family shares an address', async () => {
+    const testDb = db.__getCurrentDb();
+    // Regression: an unattributed card_delivery failure badged all four members of a
+    // family, because sub-members carry the primary's email address.
+    const primary = insertMember(testDb, {
+      email: 'shared@t.com', first_name: 'Pat', status: 'active',
+      membership_type: 'family', expiry_date: isoDate(-5),
+    });
+    for (const name of ['Kid', 'Spouse']) {
+      insertMember(testDb, {
+        email: 'shared@t.com', first_name: name, status: 'active', membership_type: 'family',
+        primary_member_id: primary.id, expiry_date: isoDate(-5),
+      });
+    }
+    insertEmailLog(testDb, { member_id: null, to_email: 'shared@t.com', email_type: 'card_delivery', status: 'failed' });
+
+    const { members } = await memberRepo.search({ view: 'needs-attention', signal: 'email_send_failed' });
+    expect(members.map(m => m.first_name)).toEqual(['Pat']);
+  });
+
+  test('email_send_failed still flags a sub-member whose own send failed', async () => {
+    const testDb = db.__getCurrentDb();
+    const primary = insertMember(testDb, {
+      email: 'shared@t.com', first_name: 'Pat', status: 'active',
+      membership_type: 'family', expiry_date: isoDate(-5),
+    });
+    const sub = insertMember(testDb, {
+      email: 'shared@t.com', first_name: 'Kid', status: 'active', membership_type: 'family',
+      primary_member_id: primary.id, expiry_date: isoDate(-5),
+    });
+    // Attributed directly, so precision is not in question — this must still match.
+    insertEmailLog(testDb, { member_id: sub.id, to_email: 'shared@t.com', email_type: 'card_delivery', status: 'failed' });
+
+    const { members } = await memberRepo.search({ view: 'needs-attention', signal: 'email_send_failed' });
+    expect(members.map(m => m.first_name).sort()).toEqual(['Kid']);
+  });
+
+  test('email_send_failed clears once a later send to the address succeeds', async () => {
+    const testDb = db.__getCurrentDb();
+    const m = insertMember(testDb, { email: 'recovered@t.com', status: 'active', expiry_date: isoDate(-5) });
+    // A MailerSend quota outage, then normal service resumed.
+    insertEmailLog(testDb, {
+      member_id: m.id, to_email: 'recovered@t.com', email_type: 'renewal_reminder',
+      status: 'failed', created_at: `${isoDate(-30)} 12:00:00`,
+    });
+    insertEmailLog(testDb, {
+      member_id: m.id, to_email: 'recovered@t.com', email_type: 'renewal_reminder',
+      status: 'sent', created_at: `${isoDate(-2)} 12:00:00`,
+    });
+
+    expect(await attentionEmails({ signal: 'email_send_failed' })).toEqual([]);
+  });
+
+  test('email_send_failed still fires when the failure is the most recent attempt', async () => {
+    const testDb = db.__getCurrentDb();
+    const m = insertMember(testDb, { email: 'broken@t.com', status: 'active', expiry_date: isoDate(-5) });
+    // Success first, then it broke and stayed broken — an earlier success must not excuse it.
+    insertEmailLog(testDb, {
+      member_id: m.id, to_email: 'broken@t.com', email_type: 'welcome',
+      status: 'sent', created_at: `${isoDate(-30)} 12:00:00`,
+    });
+    insertEmailLog(testDb, {
+      member_id: m.id, to_email: 'broken@t.com', email_type: 'renewal_reminder',
+      status: 'failed', created_at: `${isoDate(-2)} 12:00:00`,
+    });
+
+    expect(await attentionEmails({ signal: 'email_send_failed' })).toEqual(['broken@t.com']);
+  });
+
+  test('email_send_failed recovery is judged per address, not per member', async () => {
+    const testDb = db.__getCurrentDb();
+    const m = insertMember(testDb, { email: 'target@t.com', status: 'active', expiry_date: isoDate(-5) });
+    insertEmailLog(testDb, {
+      member_id: m.id, to_email: 'target@t.com', email_type: 'renewal_reminder',
+      status: 'failed', created_at: `${isoDate(-30)} 12:00:00`,
+    });
+    // A later success to a DIFFERENT address proves nothing about this one.
+    insertEmailLog(testDb, {
+      member_id: m.id, to_email: 'someone.else@t.com', email_type: 'blast',
+      status: 'sent', created_at: `${isoDate(-2)} 12:00:00`,
+    });
+
+    expect(await attentionEmails({ signal: 'email_send_failed' })).toEqual(['target@t.com']);
+  });
+
+  test('renewal_never_started flags a lapsed member holding an unused token', async () => {
+    const testDb = db.__getCurrentDb();
+    const period = insertPeriod(testDb);
+    insertMember(testDb, {
+      email: 'lapsed@t.com', status: 'active', expiry_date: isoDate(-10),
+      renewal_token: 'tok-lapsed', renewal_token_expires_at: isoIn(20),
+    });
+
+    // Same token, but not lapsed yet — that is the Needs renewal pill's job, not this.
+    insertMember(testDb, {
+      email: 'upcoming@t.com', status: 'active', expiry_date: isoDate(10),
+      renewal_token: 'tok-upcoming', renewal_token_expires_at: isoIn(20),
+    });
+
+    expect(await attentionEmails({ currentPeriodId: period.id, signal: 'renewal_never_started' }))
+      .toEqual(['lapsed@t.com']);
+  });
+
+  test('renewal_never_started does not double-flag the repeatedly reminded', async () => {
+    const testDb = db.__getCurrentDb();
+    const period = insertPeriod(testDb);
+    const m = insertMember(testDb, {
+      email: 'reminded@t.com', status: 'active', expiry_date: isoDate(-10),
+      renewal_token: 'tok', renewal_token_expires_at: isoIn(20),
+    });
+    insertEmailLog(testDb, { member_id: m.id, email_type: 'renewal_reminder' });
+    insertEmailLog(testDb, { member_id: m.id, email_type: 'renewal_reminder' });
+
+    const ctx = { currentPeriodId: period.id };
+    // The two signals partition on reminder count rather than both firing.
+    expect(await attentionEmails({ ...ctx, signal: 'repeated_reminders' })).toEqual(['reminded@t.com']);
+    expect(await attentionEmails({ ...ctx, signal: 'renewal_never_started' })).toEqual([]);
+  });
+
+  test('renewal_never_started ignores an expired token', async () => {
+    const testDb = db.__getCurrentDb();
+    const period = insertPeriod(testDb);
+    insertMember(testDb, {
+      email: 'stale-token@t.com', status: 'active', expiry_date: isoDate(-10),
+      renewal_token: 'tok', renewal_token_expires_at: isoIn(-1),
+    });
+
+    expect(await attentionEmails({ currentPeriodId: period.id, signal: 'renewal_never_started' })).toEqual([]);
+  });
+
+  test('cancelled members are never flagged', async () => {
+    const testDb = db.__getCurrentDb();
+    const m = insertMember(testDb, { email: 'gone@t.com', status: 'cancelled' });
+    insertPayment(testDb, { member_id: m.id, status: 'failed' });
+    insertEmailLog(testDb, { member_id: m.id, email_type: 'card_delivery', status: 'failed' });
+
+    expect(await attentionEmails({})).toEqual([]);
+  });
+
+  test('members enrolled in the current period are never flagged', async () => {
+    const testDb = db.__getCurrentDb();
+    // Regression: a family whose card emails failed on a MailerSend quota error was
+    // badged even though every member had paid for the current season.
+    const period = insertPeriod(testDb);
+    const paidUp = insertMember(testDb, { email: 'paidup@t.com', status: 'active', expiry_date: isoDate(350) });
+    enrollMember(testDb, paidUp.id, period.id);
+    insertEmailLog(testDb, { member_id: paidUp.id, email_type: 'card_delivery', status: 'failed' });
+    insertPayment(testDb, { member_id: paidUp.id, status: 'failed' });
+
+    expect(await attentionEmails({ currentPeriodId: period.id })).toEqual([]);
+  });
+
+  test('a member with no expiry date but no current enrollment is still eligible', async () => {
+    const testDb = db.__getCurrentDb();
+    // Most of the membership predates expiry tracking and has a NULL expiry_date.
+    // Treating NULL as "in good standing" silently dropped ~106 of 172 active members
+    // who had genuinely not renewed.
+    const period = insertPeriod(testDb);
+    const m = insertMember(testDb, { email: 'noexpiry@t.com', status: 'active', expiry_date: null });
+    insertEmailLog(testDb, { member_id: m.id, email_type: 'card_delivery', status: 'failed' });
+
+    expect(await attentionEmails({ currentPeriodId: period.id })).toEqual(['noexpiry@t.com']);
+  });
+
+  test('a future expiry date does not excuse a missing current enrollment', async () => {
+    const testDb = db.__getCurrentDb();
+    // expiry_date is set from the period end date on payment, so it can point past today
+    // while the member has not paid for the season now open. Enrollment is the truth.
+    const period = insertPeriod(testDb);
+    const m = insertMember(testDb, { email: 'staleexpiry@t.com', status: 'active', expiry_date: isoDate(350) });
+    insertEmailLog(testDb, { member_id: m.id, email_type: 'card_delivery', status: 'failed' });
+
+    expect(await attentionEmails({ currentPeriodId: period.id })).toEqual(['staleexpiry@t.com']);
+  });
+
+  test('with no current period, only cancelled and lifetime members are excluded', async () => {
+    const testDb = db.__getCurrentDb();
+    const m = insertMember(testDb, { email: 'offseason@t.com', status: 'active' });
+    insertEmailLog(testDb, { member_id: m.id, email_type: 'card_delivery', status: 'failed' });
+
+    // Degrades to a wider list rather than an empty one.
+    expect(await attentionEmails({ currentPeriodId: null })).toEqual(['offseason@t.com']);
+  });
+
+  test('lifetime members are never flagged', async () => {
+    const testDb = db.__getCurrentDb();
+    const m = insertMember(testDb, { email: 'life@t.com', status: 'active', is_lifetime: 1, expiry_date: isoDate(-400) });
+    insertEmailLog(testDb, { member_id: m.id, email_type: 'card_delivery', status: 'failed' });
+
+    // Lifetime members never renew, so a stale expiry date must not drag them in.
+    expect(await attentionEmails({})).toEqual([]);
+  });
+
+  test('a lapsed member still carrying status=active is eligible', async () => {
+    const testDb = db.__getCurrentDb();
+    const period = insertPeriod(testDb);
+    // Nothing in the app ever writes status='expired', so this is what every lapsed
+    // member actually looks like. Gating on the raw status would make the renewal
+    // signals unreachable.
+    const lapsed = insertMember(testDb, { email: 'lapsed@t.com', status: 'active', expiry_date: isoDate(-5) });
+    insertEmailLog(testDb, { member_id: lapsed.id, email_type: 'renewal_reminder' });
+    insertEmailLog(testDb, { member_id: lapsed.id, email_type: 'renewal_reminder' });
+
+    expect(await attentionEmails({ currentPeriodId: period.id })).toEqual(['lapsed@t.com']);
+  });
+
+  test('a clean active enrolled member is never flagged', async () => {
+    const testDb = db.__getCurrentDb();
+    const period = insertPeriod(testDb);
+    const m = insertMember(testDb, { email: 'happy@t.com', status: 'active', expiry_date: isoDate(200) });
+    insertPayment(testDb, { member_id: m.id, status: 'completed' });
+    insertEmailLog(testDb, { member_id: m.id, email_type: 'welcome', status: 'sent' });
+    enrollMember(testDb, m.id, period.id);
+
+    expect(await attentionEmails({ currentPeriodId: period.id })).toEqual([]);
+  });
+
+  test('a member tripping two signals appears exactly once', async () => {
+    const testDb = db.__getCurrentDb();
+    const m = insertMember(testDb, { email: 'doubly@t.com', status: 'pending', created_at: hoursAgo(48) });
+    insertPayment(testDb, { member_id: m.id, status: 'failed' });
+    insertEmailLog(testDb, { member_id: m.id, email_type: 'welcome', status: 'failed' });
+
+    const { members, total } = await memberRepo.search({ view: 'needs-attention' });
+    expect(total).toBe(1);
+    expect(members).toHaveLength(1);
+  });
+
+  test('a null current period disables the period-dependent signals only', async () => {
+    const testDb = db.__getCurrentDb();
+    // Would trip repeated_reminders if a period existed.
+    const reminded = insertMember(testDb, { email: 'reminded@t.com', status: 'active', expiry_date: isoDate(-5) });
+    insertEmailLog(testDb, { member_id: reminded.id, email_type: 'renewal_reminder' });
+    insertEmailLog(testDb, { member_id: reminded.id, email_type: 'renewal_reminder' });
+    // Period-independent.
+    const declined = insertMember(testDb, { email: 'declined@t.com', status: 'pending' });
+    insertPayment(testDb, { member_id: declined.id, status: 'failed' });
+
+    expect(await attentionEmails({ currentPeriodId: null })).toEqual(['declined@t.com']);
+  });
+
+  test('an unknown signal key matches nobody rather than everybody', async () => {
+    const testDb = db.__getCurrentDb();
+    const m = insertMember(testDb, { email: 'flagged@t.com', status: 'pending' });
+    insertPayment(testDb, { member_id: m.id, status: 'failed' });
+
+    const clause = memberAttention.attentionClause({ signal: 'not_a_real_signal' });
+    const rows = await db.all(`SELECT id FROM members WHERE ${clause.sql}`, ...clause.params);
+    expect(rows).toEqual([]);
+  });
+
+  test('needs-attention composes with the search box', async () => {
+    const testDb = db.__getCurrentDb();
+    const a = insertMember(testDb, { email: 'aaron@t.com', first_name: 'Aaron', status: 'pending' });
+    const b = insertMember(testDb, { email: 'bella@t.com', first_name: 'Bella', status: 'pending' });
+    insertPayment(testDb, { member_id: a.id, status: 'failed' });
+    insertPayment(testDb, { member_id: b.id, status: 'failed' });
+
+    expect(await attentionEmails({ search: 'bella' })).toEqual(['bella@t.com']);
+  });
+
+  test('countByView reports the needs-attention total', async () => {
+    const testDb = db.__getCurrentDb();
+    const m = insertMember(testDb, { email: 'flagged@t.com', status: 'pending' });
+    insertPayment(testDb, { member_id: m.id, status: 'failed' });
+
+    const counts = await memberRepo.countByView(null);
+    expect(counts.needsAttention).toBe(1);
+  });
+});
+
+describe('signalsForIds', () => {
+  test('returns exactly the signals that fired, per member', async () => {
+    const testDb = db.__getCurrentDb();
+    const declined = insertMember(testDb, { email: 'declined@t.com', status: 'pending' });
+    insertPayment(testDb, { member_id: declined.id, status: 'failed' });
+
+    const bounced = insertMember(testDb, { email: 'bounced@t.com', status: 'active' });
+    insertEmailLog(testDb, { member_id: bounced.id, email_type: 'welcome', status: 'failed' });
+
+    const map = await memberAttention.signalsForIds([declined.id, bounced.id], {});
+    expect(map.get(declined.id).map(s => s.key)).toEqual(['payment_failed']);
+    expect(map.get(bounced.id).map(s => s.key)).toEqual(['email_send_failed']);
+  });
+
+  test('reports every signal a member trips', async () => {
+    const testDb = db.__getCurrentDb();
+    const m = insertMember(testDb, { email: 'doubly@t.com', status: 'pending', created_at: hoursAgo(48) });
+    insertPayment(testDb, { member_id: m.id, status: 'failed' });
+    insertEmailLog(testDb, { member_id: m.id, email_type: 'welcome', status: 'failed' });
+
+    const map = await memberAttention.signalsForIds([m.id], {});
+    expect(map.get(m.id).map(s => s.key).sort()).toEqual(['email_send_failed', 'payment_failed']);
+  });
+
+  test('returns an empty list for a clean member', async () => {
+    const testDb = db.__getCurrentDb();
+    const m = insertMember(testDb, { email: 'clean@t.com', status: 'active' });
+
+    const map = await memberAttention.signalsForIds([m.id], {});
+    expect(map.get(m.id)).toEqual([]);
+  });
+
+  test('signals carry a label and a short badge text', async () => {
+    const testDb = db.__getCurrentDb();
+    const m = insertMember(testDb, { email: 'declined@t.com', status: 'pending' });
+    insertPayment(testDb, { member_id: m.id, status: 'failed' });
+
+    const [signal] = (await memberAttention.signalsForIds([m.id], {})).get(m.id);
+    expect(signal).toEqual({ key: 'payment_failed', label: expect.any(String), short: expect.any(String) });
+    expect(signal.short.length).toBeGreaterThan(0);
+  });
+
+  test('an empty id list returns an empty map without querying', async () => {
+    const map = await memberAttention.signalsForIds([], {});
+    expect(map.size).toBe(0);
+  });
+
+  test('chunks past the SQLite bound-parameter ceiling', async () => {
+    const testDb = db.__getCurrentDb();
+    const ids = [];
+    for (let i = 0; i < 450; i++) {
+      ids.push(insertMember(testDb, { email: `m${i}@t.com`, status: 'active' }).id);
+    }
+    // 450 ids exceeds the 400-per-chunk limit, and the predicate params ride along on
+    // each chunk — this would blow the 999-param ceiling in a single statement.
+    const map = await memberAttention.signalsForIds(ids, {});
+    expect(map.size).toBe(450);
+  });
+
+  test('attribution agrees with the filter that selected the rows', async () => {
+    const testDb = db.__getCurrentDb();
+    const period = insertPeriod(testDb);
+    insertMember(testDb, { email: 'clean@t.com', status: 'active', expiry_date: isoDate(100) });
+    const flagged = insertMember(testDb, { email: 'flagged@t.com', status: 'pending', created_at: hoursAgo(48) });
+    insertPayment(testDb, { member_id: flagged.id, status: 'pending', created_at: hoursAgo(48) });
+
+    const ctx = { currentPeriodId: period.id };
+    const { members } = await memberRepo.search({ view: 'needs-attention', ...ctx });
+    const map = await memberAttention.signalsForIds(members.map(m => m.id), ctx);
+
+    // Every row the filter returned must have at least one badge, or the coordinator
+    // sees a member with no stated reason.
+    expect(members.length).toBeGreaterThan(0);
+    for (const member of members) {
+      expect(map.get(member.id).length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/test/repos/members.test.js
+++ b/test/repos/members.test.js
@@ -307,6 +307,9 @@ describe('countByView', () => {
       recentlyRenewed: 1,
       pending: 1,
       lifetime: 1,
+      // The pending member was created just now, so it is still inside the
+      // unfinished-checkout grace period and nothing is flagged yet.
+      needsAttention: 0,
     });
   });
 

--- a/test/routes/admin-members-attention-http.test.js
+++ b/test/routes/admin-members-attention-http.test.js
@@ -1,0 +1,274 @@
+/**
+ * HTTP integration test for the Needs attention members filter: the real Express app,
+ * real session + CSRF middleware, a real admin login, real Pug rendering and a real CSV
+ * body. Only the database is swapped for the in-memory SQLite proxy.
+ */
+process.env.NODE_ENV = 'test';
+
+jest.mock('../../db/database', () => require('../helpers/setupDb'));
+jest.mock('../../services/email', () => ({
+  sendOtpEmail: jest.fn().mockResolvedValue({}),
+}));
+
+const request = require('supertest');
+const app = require('../../server');
+const db = require('../../db/database');
+const { SIGNAL_LABELS } = require('../../db/repos/memberAttention');
+const {
+  insertMember, insertAdmin, insertPayment, insertEmailLog, insertPeriod, enrollMember,
+} = require('../helpers/fixtures');
+
+function labelFor(key) {
+  return SIGNAL_LABELS.find(s => s.key === key).label;
+}
+
+const TEST_OTP = '000000';
+
+function tokenFrom(html) {
+  const match = html.match(/name="_csrf" value="([^"]+)"/);
+  if (!match) throw new Error('No CSRF token in response');
+  return match[1];
+}
+
+async function loginAsAdmin(email) {
+  const agent = request.agent(app);
+  const loginPage = await agent.get('/admin/login').expect(200);
+  await agent.post('/admin/login')
+    .type('form')
+    .send({ _csrf: tokenFrom(loginPage.text), email })
+    .expect(302);
+  const verifyPage = await agent.get('/admin/login/verify').expect(200);
+  await agent.post('/admin/login/verify')
+    .type('form')
+    .send({ _csrf: tokenFrom(verifyPage.text), code: TEST_OTP })
+    .expect(302);
+  return agent;
+}
+
+function isoDate(offsetDays = 0) {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+}
+
+function hoursAgo(hours) {
+  return new Date(Date.now() - hours * 60 * 60 * 1000).toISOString().slice(0, 19).replace('T', ' ');
+}
+
+let agent;
+let period;
+
+beforeEach(async () => {
+  db.__resetTestDb();
+  // Must actually span today, or periodsRepo.getCurrent() returns null and the
+  // period-dependent signals go dark — which is correct behavior, but not what these
+  // tests are exercising.
+  period = insertPeriod(db, {
+    label: 'Current Season',
+    start_date: isoDate(-30),
+    end_date: isoDate(300),
+  });
+  insertAdmin(db, { email: 'admin@ysh.test' });
+  agent = await loginAsAdmin('admin@ysh.test');
+});
+
+/** A member with a declined card payment. */
+function seedDeclined(email = 'declined@t.com') {
+  const m = insertMember(db, { email, first_name: 'Dana', last_name: 'Declined', status: 'pending' });
+  insertPayment(db, { member_id: m.id, status: 'failed' });
+  return m;
+}
+
+/**
+ * A lapsed member whose card email could not be sent. Lapsed rather than paid up,
+ * because the eligibility gate excludes anyone in good standing.
+ */
+function seedBounced(email = 'bounced@t.com') {
+  const m = insertMember(db, {
+    email, first_name: 'Boris', last_name: 'Bounced', status: 'active', expiry_date: isoDate(-5),
+  });
+  insertEmailLog(db, { member_id: m.id, email_type: 'card_delivery', status: 'failed' });
+  return m;
+}
+
+describe('GET /admin/members needs-attention view', () => {
+  test('the pill renders with a live count', async () => {
+    seedDeclined();
+    const res = await agent.get('/admin/members').expect(200);
+    expect(res.text).toContain('Needs attention');
+    expect(res.text).toContain('view=needs-attention');
+  });
+
+  test('lists only flagged members and badges the reason', async () => {
+    seedDeclined();
+    const clean = insertMember(db, { email: 'clean@t.com', first_name: 'Casey', status: 'active', expiry_date: isoDate(200) });
+    insertPayment(db, { member_id: clean.id, status: 'completed' });
+    enrollMember(db, clean.id, period.id);
+
+    const res = await agent.get('/admin/members?view=needs-attention').expect(200);
+    expect(res.text).toContain('declined@t.com');
+    expect(res.text).not.toContain('clean@t.com');
+    expect(res.text).toContain('badge-attention');
+    expect(res.text).toContain('Payment failed');
+  });
+
+  test('shows no Signals column outside the needs-attention view', async () => {
+    seedDeclined();
+    const res = await agent.get('/admin/members').expect(200);
+    expect(res.text).not.toContain('badge-attention');
+  });
+
+  test('the signal select is only offered under the needs-attention view', async () => {
+    seedDeclined();
+    const off = await agent.get('/admin/members').expect(200);
+    expect(off.text).not.toContain('name="signal"');
+
+    const on = await agent.get('/admin/members?view=needs-attention').expect(200);
+    expect(on.text).toContain('name="signal"');
+    // Must carry data-auto-submit, since helmet's script-src-attr 'none' rules out an
+    // inline onchange handler.
+    expect(on.text).toMatch(/select\(?[^>]*name="signal"[^>]*data-auto-submit/);
+  });
+
+  test('the signal parameter narrows to one signal', async () => {
+    seedDeclined();
+    seedBounced();
+
+    const res = await agent.get('/admin/members?view=needs-attention&signal=payment_failed').expect(200);
+    expect(res.text).toContain('declined@t.com');
+    expect(res.text).not.toContain('bounced@t.com');
+  });
+
+  test('an unknown signal value is ignored rather than erroring', async () => {
+    seedDeclined();
+    const res = await agent.get('/admin/members?view=needs-attention&signal=nonsense').expect(200);
+    // Falls back to the full OR group instead of 500ing or matching nobody.
+    expect(res.text).toContain('declined@t.com');
+  });
+
+  test('the signal survives a sort link', async () => {
+    seedDeclined();
+    const res = await agent.get('/admin/members?view=needs-attention&signal=payment_failed').expect(200);
+    // Every sort link has to carry the signal, or clicking a column header silently
+    // widens the list back out.
+    expect(res.text).toMatch(/signal=payment_failed[^"]*sort=|sort=[^"]*signal=payment_failed/);
+  });
+
+  test('composes with the search box', async () => {
+    seedDeclined();
+    seedBounced();
+    const res = await agent.get('/admin/members?view=needs-attention&search=declined').expect(200);
+    expect(res.text).toContain('declined@t.com');
+    expect(res.text).not.toContain('bounced@t.com');
+  });
+
+  test('offers a clear-filters link when only a signal is set', async () => {
+    seedDeclined();
+    const res = await agent.get('/admin/members?view=needs-attention&signal=payment_failed').expect(200);
+    expect(res.text).toContain('Clear filters');
+  });
+
+  test('shows a reassuring empty state when nothing is wrong', async () => {
+    insertMember(db, { email: 'clean@t.com', status: 'active', expiry_date: isoDate(200) });
+    const res = await agent.get('/admin/members?view=needs-attention').expect(200);
+    expect(res.text).toContain('No members need attention right now');
+  });
+
+  test('does not flag a family enrolled in the current season whose card emails failed', async () => {
+    // Regression for the MailerSend quota case: a whole family badged from two failed
+    // card emails, despite every member having paid for the current season. The null
+    // member_id on the failed row makes it match all of them via the shared address.
+    const primary = insertMember(db, {
+      email: 'family@t.com', first_name: 'Pat', last_name: 'Primary',
+      status: 'active', membership_type: 'family', expiry_date: isoDate(350),
+    });
+    enrollMember(db, primary.id, period.id);
+    insertEmailLog(db, { member_id: null, to_email: 'family@t.com', email_type: 'card_delivery', status: 'failed' });
+    for (const name of ['Kid', 'Spouse']) {
+      const sub = insertMember(db, {
+        email: 'family@t.com', first_name: name, last_name: 'Primary', status: 'active',
+        membership_type: 'family', primary_member_id: primary.id, expiry_date: isoDate(350),
+      });
+      enrollMember(db, sub.id, period.id);
+    }
+
+    const res = await agent.get('/admin/members?view=needs-attention').expect(200);
+    expect(res.text).toContain('No members need attention right now');
+  });
+
+  test('still flags a lapsed member with a stale future expiry date', async () => {
+    // The over-correction to watch for: excluding anyone whose expiry_date is in the
+    // future dropped most of the membership, because expiry_date tracks the period they
+    // last paid for, not the one now open.
+    insertMember(db, {
+      email: 'stale@t.com', first_name: 'Sam', last_name: 'Stale',
+      status: 'active', expiry_date: isoDate(350),
+    });
+    insertEmailLog(db, { member_id: null, to_email: 'stale@t.com', email_type: 'card_delivery', status: 'failed' });
+
+    const res = await agent.get('/admin/members?view=needs-attention').expect(200);
+    expect(res.text).toContain('stale@t.com');
+  });
+
+  test('reflects the reminder-count setting', async () => {
+    const m = insertMember(db, {
+      email: 'once@t.com', first_name: 'Olive', status: 'active', expiry_date: isoDate(-5),
+    });
+    insertEmailLog(db, { member_id: m.id, email_type: 'renewal_reminder' });
+
+    const beforeRes = await agent.get('/admin/members?view=needs-attention&signal=repeated_reminders').expect(200);
+    expect(beforeRes.text).not.toContain('once@t.com');
+
+    db.prepare("INSERT OR REPLACE INTO site_settings (key, value) VALUES ('attention_reminder_count', '1')").run();
+
+    const afterRes = await agent.get('/admin/members?view=needs-attention&signal=repeated_reminders').expect(200);
+    expect(afterRes.text).toContain('once@t.com');
+  });
+});
+
+describe('GET /admin/members/export needs-attention view', () => {
+  test('appends a Signals column with the labels', async () => {
+    seedDeclined();
+    const res = await agent.get('/admin/members/export?view=needs-attention')
+      .expect(200)
+      .expect('Content-Type', /text\/csv/);
+
+    const [header, ...rows] = res.text.trim().split('\n');
+    expect(header).toContain('Signals');
+    expect(rows.join('\n')).toContain(labelFor('payment_failed'));
+  });
+
+  test('names the file after the view', async () => {
+    seedDeclined();
+    const res = await agent.get('/admin/members/export?view=needs-attention').expect(200);
+    expect(res.headers['content-disposition']).toContain('needs-attention');
+  });
+
+  test('joins multiple signals into one cell', async () => {
+    const m = insertMember(db, {
+      email: 'doubly@t.com', first_name: 'Dee', status: 'pending', created_at: hoursAgo(48),
+    });
+    insertPayment(db, { member_id: m.id, status: 'failed' });
+    insertEmailLog(db, { member_id: m.id, email_type: 'welcome', status: 'failed' });
+
+    const res = await agent.get('/admin/members/export?view=needs-attention').expect(200);
+    expect(res.text).toContain(';');
+    // Taken from the source so a reworded label cannot quietly break this.
+    expect(res.text).toContain(labelFor('payment_failed'));
+    expect(res.text).toContain(labelFor('email_send_failed'));
+  });
+
+  test('omits the Signals column for other views', async () => {
+    seedDeclined();
+    const res = await agent.get('/admin/members/export').expect(200);
+    expect(res.text.split('\n')[0]).not.toContain('Signals');
+  });
+
+  test('honors the signal filter', async () => {
+    seedDeclined();
+    seedBounced();
+    const res = await agent.get('/admin/members/export?view=needs-attention&signal=payment_failed').expect(200);
+    expect(res.text).toContain('declined@t.com');
+    expect(res.text).not.toContain('bounced@t.com');
+  });
+});

--- a/test/routes/stripe-webhook.test.js
+++ b/test/routes/stripe-webhook.test.js
@@ -1,7 +1,7 @@
 jest.mock('../../db/database', () => require('../helpers/setupDb'));
 
 const db = require('../../db/database');
-const { insertMember, insertPeriod } = require('../helpers/fixtures');
+const { insertMember, insertPeriod, insertPayment } = require('../helpers/fixtures');
 
 const mockHandlers = {};
 jest.mock('express', () => {
@@ -116,5 +116,124 @@ describe('POST /webhook — checkout.session.completed', () => {
 
     expect(res.json).toHaveBeenCalledWith({ received: true });
     expect(emailService.sendWelcomeEmail).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * Failure events are what give the Needs attention filter its payment signals — before
+ * these branches existed, payments.status = 'failed' was declared in the schema but
+ * never written by any code path.
+ */
+describe('POST /webhook — checkout.session.expired', () => {
+  async function fire(session) {
+    stripeService.constructWebhookEvent.mockReturnValue({
+      type: 'checkout.session.expired', data: { object: session },
+    });
+    const res = mockRes();
+    await mockHandlers['POST /webhook'](mockReq(), res);
+    return res;
+  }
+
+  test('flips the pending payment to failed', async () => {
+    const testDb = getTestDb();
+    const member = insertMember(testDb, { email: 'abandoned@test.com', status: 'pending' });
+    insertPayment(testDb, { member_id: member.id, status: 'pending', stripe_session_id: 'cs_exp_1' });
+
+    const res = await fire({ id: 'cs_exp_1' });
+
+    expect(res.json).toHaveBeenCalledWith({ received: true });
+    const row = testDb.prepare('SELECT status, failure_reason FROM payments WHERE stripe_session_id = ?').get('cs_exp_1');
+    expect(row.status).toBe('failed');
+    expect(row.failure_reason).toBe('Checkout session expired');
+  });
+
+  test('is idempotent on redelivery', async () => {
+    const testDb = getTestDb();
+    const member = insertMember(testDb, { email: 'abandoned@test.com', status: 'pending' });
+    insertPayment(testDb, { member_id: member.id, status: 'pending', stripe_session_id: 'cs_exp_2' });
+
+    await fire({ id: 'cs_exp_2' });
+    await fire({ id: 'cs_exp_2' });
+
+    const rows = testDb.prepare("SELECT id FROM payments WHERE stripe_session_id = ? AND status = 'failed'").all('cs_exp_2');
+    expect(rows).toHaveLength(1);
+  });
+
+  test('never clobbers a payment that already completed', async () => {
+    const testDb = getTestDb();
+    const member = insertMember(testDb, { email: 'paid@test.com', status: 'active' });
+    insertPayment(testDb, { member_id: member.id, status: 'completed', stripe_session_id: 'cs_exp_3' });
+
+    await fire({ id: 'cs_exp_3' });
+
+    const row = testDb.prepare('SELECT status FROM payments WHERE stripe_session_id = ?').get('cs_exp_3');
+    expect(row.status).toBe('completed');
+  });
+
+  test('tolerates a session it has no payment row for', async () => {
+    const res = await fire({ id: 'cs_unknown' });
+    expect(res.json).toHaveBeenCalledWith({ received: true });
+  });
+});
+
+describe('POST /webhook — payment_intent.payment_failed', () => {
+  async function fire(intent) {
+    stripeService.constructWebhookEvent.mockReturnValue({
+      type: 'payment_intent.payment_failed', data: { object: intent },
+    });
+    const res = mockRes();
+    await mockHandlers['POST /webhook'](mockReq(), res);
+    return res;
+  }
+
+  test('records a failed payment against the member', async () => {
+    const testDb = getTestDb();
+    const member = insertMember(testDb, { email: 'declined@test.com', status: 'pending' });
+
+    const res = await fire({
+      id: 'pi_fail_1',
+      amount: 1600,
+      metadata: { member_id: String(member.id) },
+      last_payment_error: { message: 'Your card was declined.' },
+    });
+
+    expect(res.json).toHaveBeenCalledWith({ received: true });
+    const row = testDb.prepare('SELECT * FROM payments WHERE stripe_payment_intent = ?').get('pi_fail_1');
+    expect(row.status).toBe('failed');
+    expect(row.member_id).toBe(member.id);
+    expect(row.amount_cents).toBe(1600);
+    expect(row.failure_reason).toBe('Your card was declined.');
+  });
+
+  test('is idempotent on redelivery', async () => {
+    const testDb = getTestDb();
+    const member = insertMember(testDb, { email: 'declined@test.com', status: 'pending' });
+    const intent = { id: 'pi_fail_2', amount: 1600, metadata: { member_id: String(member.id) } };
+
+    await fire(intent);
+    await fire(intent);
+
+    const rows = testDb.prepare('SELECT id FROM payments WHERE stripe_payment_intent = ?').all('pi_fail_2');
+    expect(rows).toHaveLength(1);
+  });
+
+  test('falls back to a generic reason when Stripe gives none', async () => {
+    const testDb = getTestDb();
+    const member = insertMember(testDb, { email: 'declined@test.com', status: 'pending' });
+
+    await fire({ id: 'pi_fail_3', amount: 1600, metadata: { member_id: String(member.id) } });
+
+    const row = testDb.prepare('SELECT failure_reason FROM payments WHERE stripe_payment_intent = ?').get('pi_fail_3');
+    expect(row.failure_reason).toBe('Payment failed');
+  });
+
+  test('no-ops without member_id metadata', async () => {
+    const testDb = getTestDb();
+
+    const res = await fire({ id: 'pi_fail_4', amount: 1600, metadata: {} });
+
+    expect(res.json).toHaveBeenCalledWith({ received: true });
+    const rows = testDb.prepare('SELECT id FROM payments').all();
+    expect(rows).toHaveLength(0);
   });
 });

--- a/test/services/stripe.test.js
+++ b/test/services/stripe.test.js
@@ -52,6 +52,14 @@ describe('createCheckoutSession', () => {
     expect(callArgs.metadata.member_id).toBe(String(baseParams.memberId));
   });
 
+  test('copies metadata onto the payment intent', async () => {
+    await createCheckoutSession(baseParams);
+    const callArgs = mockSessionCreate.mock.calls[0][0];
+    // A payment_intent.payment_failed event carries the intent, not the session, so
+    // without this the failure cannot be attributed to a member.
+    expect(callArgs.payment_intent_data.metadata.member_id).toBe(String(baseParams.memberId));
+  });
+
   test('sets correct success and cancel URLs', async () => {
     await createCheckoutSession(baseParams);
     const callArgs = mockSessionCreate.mock.calls[0][0];

--- a/user_guide/02-managing-members.md
+++ b/user_guide/02-managing-members.md
@@ -6,6 +6,20 @@ Navigate to **Members** in the sidebar. The list displays 25 members per page an
 
 Each row shows the member's name, email, member number, status, and join date.
 
+Above the list is a row of filter pills, each with a count:
+
+| Pill                 | Shows                                                              |
+|----------------------|--------------------------------------------------------------------|
+| **All**              | Every member                                                       |
+| **Active**           | Paid and in good standing                                          |
+| **Needs renewal**    | Expiring within the next 30 days and not yet renewed               |
+| **Recently renewed** | Renewed in the last 30 days                                        |
+| **Pending**          | Signed up, payment not completed                                   |
+| **Lifetime**         | Lifetime members                                                   |
+| **Needs attention**  | Looks like they tried to join or renew and something went wrong     |
+
+See [Needs Attention](#needs-attention) below for the last one.
+
 ## Member Statuses
 
 | Status        | Meaning                                         |
@@ -47,6 +61,10 @@ Type a query into the search bar and press Enter. The search matches against:
 
 Clear the search field and press Enter to return to the full list.
 
+Search combines with the other filters rather than replacing them. A search inside the **Needs attention** pill
+searches only the flagged members, and the same is true of the period and status dropdowns. **Clear filters** appears
+whenever any of them is active.
+
 ## Family Memberships
 
 A family membership has a primary member and up to 6 additional family members. Family members share the primary's
@@ -70,3 +88,60 @@ they can renew.
 ## Renewal Reminders
 
 See [Email System](06-email-system.md) for bulk and individual renewal reminder workflows.
+
+## Needs Attention
+
+This is the outreach list. It collects members who look like they *meant* to join or renew but didn't finish — the
+people who fall through the cracks because nothing else in the app flags them. A pending signup that died at the
+payment screen looks exactly like one created five minutes ago, and a renewal reminder that landed in someone's spam
+folder leaves no visible trace.
+
+Members who have **already paid for the current season** never appear here, no matter what went wrong for them earlier —
+there is nothing to chase. Lifetime and cancelled members are excluded too. What's left is people who have not renewed
+for this season or never finished joining in the first place.
+
+Note that this is based on whether they are enrolled in the current membership period, not on the **Active** badge in
+the status column. A member can show as Active and still belong on this list, because nothing automatically flips a
+member to Expired when their membership lapses.
+
+Click the **Needs attention** pill. Each row is badged with the problem or problems found:
+
+| Badge                     | What it means                                                                                    | What to do                                                                                              |
+|---------------------------|--------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
+| **Reminded, not renewed** | They have received several renewal reminders and still haven't renewed                            | Call or text. Repeated silence usually means the emails are being filtered, not ignored                 |
+| **Payment failed**        | Stripe declined their card and they have not paid since                                          | Call. Most people don't realize it failed. Ask them to retry, or take a check                            |
+| **Checkout not finished** | They reached the payment screen and never completed it                                            | Call. Often a card they didn't have on hand, or a checkout they meant to come back to                    |
+| **Never reached checkout**| They submitted the signup form but never got to payment                                          | Call. This can mean the signup itself errored, so confirm their details are right before asking them to retry |
+| **Duplicate signup**      | Two unpaid signups exist for the same email address                                              | Sort out which record is real and delete the other **before** calling, so you don't set up a double charge |
+| **Email send failed**     | An email to them failed and nothing has reached that address since                                | Do not email — phone them, and check the address on file for a typo                                       |
+| **Renewal never started** | Their membership has lapsed and they were sent a renewal link they never used                     | Call. They may not have seen the reminder at all                                                          |
+
+Hover a badge to see a longer description. A member can carry more than one badge — someone who signed up twice and had
+a card declined shows both.
+
+### Working the list
+
+- Use the **Any problem** dropdown to narrow to a single badge, so you can batch similar calls together. The list
+  updates as soon as you change the dropdown.
+- **Export CSV** downloads the current list with a **Signals** column containing each member's problems, which is what
+  makes it usable as a call sheet. The export respects whatever filters are active.
+- Combine with the search box or the period and status dropdowns to narrow further.
+
+### Expect a backlog the first time
+
+The first time you open this pill, it will likely be long. It is reporting problems going back several months, not just
+today's, so treat the first pass as a cleanup project rather than a daily queue. After you work through it once, the
+list should stay short and a growing count is a signal worth investigating.
+
+Two more things worth knowing:
+
+- **Payment failed** only reports declines that Stripe told us about. It stays empty unless the Stripe webhook events
+  are configured — see [Payments & Stripe](04-payments-and-stripe.md).
+- **Email send failed** catches emails that could not be sent at all, and clears itself once anything reaches that
+  address again — so a past outage on our mail provider won't leave people badged. On a family membership it flags the
+  primary rather than every member sharing the address, unless a specific person's own email failed. It does **not**
+  catch email that was accepted and then bounced, or that landed in a spam folder — the app cannot see either. See
+  [Email System](06-email-system.md).
+
+The thresholds behind these badges (how many reminders, how long an unfinished checkout has to sit, how far back to
+look) are configurable — see [Site Settings](07-site-settings.md).

--- a/user_guide/04-payments-and-stripe.md
+++ b/user_guide/04-payments-and-stripe.md
@@ -27,8 +27,12 @@ Navigate to **Payments** in the sidebar to view the payment ledger. It shows 25 
 |--------|---------|
 | **Pending** | Checkout session created but not yet completed |
 | **Completed** | Payment confirmed by Stripe webhook |
-| **Failed** | Payment attempt was unsuccessful |
-| **Refunded** | Payment was refunded through Stripe |
+| **Failed** | Stripe declined the card, or the checkout session expired unpaid |
+| **Refunded** | Reserved — refunds are not currently recorded in YSH; issue and track them in the Stripe Dashboard |
+
+A payment sitting at **Pending** for more than a few minutes means the member never finished checkout. Both **Pending**
+and **Failed** payments feed the **Needs attention** filter on the Members page — see
+[Managing Members](02-managing-members.md).
 
 ## Dues and Pricing
 
@@ -44,3 +48,17 @@ See [Membership Periods](08a-membership-periods.md) for details on managing seas
 ## Stripe Dashboard
 
 For refunds, disputes, or detailed transaction investigation, log into the Stripe Dashboard directly. The payment ledger in YSH is a read-only view of transaction records.
+
+### Required Webhook Events
+
+Under **Developers > Webhooks**, the YSH endpoint must be subscribed to all three of these:
+
+| Event | Why it is needed |
+|-------|------------------|
+| `checkout.session.completed` | Activates the member, enrolls them in the season, generates cards, sends email. Without it members stay **Pending** after paying. |
+| `checkout.session.expired` | Marks an abandoned checkout as **Failed**. |
+| `payment_intent.payment_failed` | Records a declined card as **Failed**, with Stripe's reason. |
+
+The last two are what make declined payments visible. If they are not subscribed, the **Payment failed** badge on the
+Members page will silently never appear — the list will look clean when it isn't. Adding them is safe at any time, but
+only affects payments made afterwards; earlier failures were never recorded and cannot be recovered.

--- a/user_guide/06-email-system.md
+++ b/user_guide/06-email-system.md
@@ -49,3 +49,19 @@ If emails show as **failed** in the log:
 1. Verify the `MAILERSEND_API_KEY` and `FROM_EMAIL` environment variables are set correctly.
 2. Check that the sender domain is verified in your MailerSend account.
 3. Review MailerSend's Activity log for bounce or block details.
+
+To find *which members* were affected rather than which messages, use the **Needs attention** filter on the Members
+page and narrow to **Email send failed** — see [Managing Members](02-managing-members.md). That gives you a list of
+people to phone instead of email.
+
+### What the log cannot tell you
+
+A **sent** status means only that MailerSend accepted the message for delivery. It does **not** mean the member
+received it. Email that was accepted and then bounced, or that was delivered straight into a spam folder, looks
+identical to email that was read — YSH receives no delivery notifications back from MailerSend, so none of it is
+visible here or anywhere else in the admin.
+
+This matters most for renewal reminders. If a member insists they never got one, the log showing **sent** does not
+contradict them. The **Reminded, not renewed** badge on the Members page exists for exactly this case: repeated
+reminders with no response is the closest thing to evidence of spam filtering that the app can offer. Check MailerSend's
+own Activity log for the actual delivery outcome.

--- a/user_guide/07-site-settings.md
+++ b/user_guide/07-site-settings.md
@@ -15,6 +15,10 @@ Navigate to **Settings** in the sidebar to configure site-wide values. Changes t
 | Gallery Album URL | External link to a full photo album | `https://photos.example.com/album` |
 | Contact Email | Email address that receives contact form submissions | `info@ysh.org` |
 | Stripe Publishable Key | Public Stripe key used on the membership form | `pk_live_...` |
+| Send Reminders (days before expiry) | How far ahead of expiry a member is included in renewal reminder sends | `30` |
+| Reminders Before Flagging | Renewal reminders a member must receive before the **Needs attention** list flags them | `2` |
+| Unfinished Checkout Age (hours) | How long a payment may sit unfinished before it counts as abandoned | `24` |
+| Lookback Window (days) | How far back the **Needs attention** list looks for problems | `180` |
 
 > **Note:** Membership dues are no longer configured here. They are managed per season in **Periods** (super admin
 > only). See [Membership Periods](08a-membership-periods.md).
@@ -29,3 +33,10 @@ Navigate to **Settings** in the sidebar to configure site-wide values. Changes t
 
 - **Stripe Publishable Key** is the public key only. The secret key and webhook secret are configured as environment variables and are not editable through the admin interface.
 - **Contact Email** determines where contact form submissions are delivered. Make sure this is a monitored inbox.
+- The three **Needs Attention** thresholds tune the outreach list on the Members page (see
+  [Managing Members](02-managing-members.md)). They trade completeness against noise:
+  - Lowering **Reminders Before Flagging** widens the list, flagging people sooner after their first reminder.
+  - Raising **Unfinished Checkout Age** stops flagging people who are still mid-checkout. Lowering it catches abandoned
+    checkouts faster but will include some people who are simply still typing.
+  - Lowering **Lookback Window** shortens the list to recent problems only. Raise it if you want to sweep further back
+    through history, but expect old, already-resolved cases to reappear.

--- a/user_guide/08-troubleshooting.md
+++ b/user_guide/08-troubleshooting.md
@@ -21,10 +21,43 @@
 
 **Problem:** A member signed up but their status never changed to active.
 
-- Check the **Payments** ledger for their transaction. If the payment shows as pending, the Stripe webhook may not have fired.
-- Verify the `STRIPE_WEBHOOK_SECRET` environment variable matches the secret in your Stripe Dashboard under Developers > Webhooks.
+Start with the **Needs attention** filter on the Members page — it identifies stuck members and tells you *why* each one
+is stuck, which determines the fix. See [Managing Members](02-managing-members.md).
+
+- **Payment failed** — Stripe declined their card. Nothing is wrong with the site; the member needs to retry or pay by
+  check.
+- **Checkout not finished** or **Never reached checkout** — they abandoned the process. Again nothing to fix
+  technically; this is an outreach case.
+- **No badge at all, but still pending after paying** — this is the actual webhook failure case. Continue below.
+
+If a member paid but stayed pending:
+
+- Check the **Payments** ledger for their transaction. If the payment shows as completed but the member is still
+  pending, the webhook fired but a later step failed — check the server logs.
+- If the payment shows as pending, the Stripe webhook may not have fired at all.
+- Verify the `STRIPE_WEBHOOK_SECRET` environment variable matches the secret in your Stripe Dashboard under Developers >
+  Webhooks, and that all three required events are subscribed (see
+  [Payments & Stripe](04-payments-and-stripe.md)).
 - Check server logs for webhook errors.
 - As a workaround, you can manually set the member's status to active from their detail page.
+
+## Needs Attention List Looks Wrong
+
+**Problem:** The **Needs attention** count seems too high, too low, or flags people who are fine.
+
+- **Far too long the first time** — expected. It reports problems going back to the lookback window, so the first pass
+  is a backlog. Work through it once and it will settle.
+- **Flagging people who are still mid-checkout** — raise **Unfinished Checkout Age (hours)** in Settings.
+- **Not flagging people you know are stuck** — lower **Reminders Before Flagging**, or check whether the lookback window
+  is shorter than the problem is old.
+- **Payment failed never appears** — the two Stripe failure events are probably not subscribed on the webhook endpoint.
+  See [Payments & Stripe](04-payments-and-stripe.md). This is the most common cause of a list that looks
+  suspiciously clean.
+- **A member is flagged but the badge seems wrong** — the badges are inferences from payment and email records, not
+  statements of fact. `docs/needs-attention-signals.md` documents exactly what each one does and does not prove.
+
+All three thresholds are on the Settings page under **Needs Attention** — see
+[Site Settings](07-site-settings.md).
 
 ## Emails Not Sending
 

--- a/user_guide/README.md
+++ b/user_guide/README.md
@@ -5,7 +5,7 @@ Welcome to the Yellowstone Sea Hawkers administration guide. These documents cov
 ## Table of Contents
 
 1. [Getting Started](01-getting-started.md) — Admin accounts, email OTP login, roles, and navigating the dashboard
-2. [Managing Members](02-managing-members.md) — Adding, editing, searching, and tracking member status
+2. [Managing Members](02-managing-members.md) — Adding, editing, searching, and tracking member status, plus the Needs attention list for stalled signups and renewals
 3. [Membership Cards](03-membership-cards.md) — Generating, downloading, and emailing PDF/PNG membership cards
 4. [Payments & Stripe](04-payments-and-stripe.md) — Understanding the payment flow, viewing the ledger, and handling Stripe
 5. [Content Management](05-content-management.md) — Announcements, gallery images, and board bios

--- a/views/admin/members/list.pug
+++ b/views/admin/members/list.pug
@@ -14,7 +14,7 @@ mixin sortTh(key, label)
 
 block content
   .view-pills
-    - const pills = [['all', 'All', counts.all], ['active', 'Active', counts.active], ['needs-renewal', 'Needs renewal', counts.needsRenewal], ['recently-renewed', 'Recently renewed', counts.recentlyRenewed], ['pending', 'Pending', counts.pending], ['lifetime', 'Lifetime', counts.lifetime]]
+    - const pills = [['all', 'All', counts.all], ['active', 'Active', counts.active], ['needs-renewal', 'Needs renewal', counts.needsRenewal], ['recently-renewed', 'Recently renewed', counts.recentlyRenewed], ['pending', 'Pending', counts.pending], ['lifetime', 'Lifetime', counts.lifetime], ['needs-attention', 'Needs attention', counts.needsAttention]]
     each pill in pills
       a(class=`view-pill${view === pill[0] ? ' view-pill-active' : ''}` href=`/admin/members${qs({view: pill[0], page: 1})}`)
         = pill[1]
@@ -39,9 +39,14 @@ block content
         option(value="expired" selected=status === 'expired') Expired
         option(value="pending" selected=status === 'pending') Pending
         option(value="cancelled" selected=status === 'cancelled') Cancelled
+      if view === 'needs-attention'
+        select(name="signal" data-auto-submit)
+          option(value="" selected=!signal) Any problem
+          each s in signalOptions
+            option(value=s.key selected=signal === s.key title=s.label)= s.short
       button.btn(type="submit") Search
-      if search || status || periodId
-        a.btn-outline(href=`/admin/members${qs({search: '', status: '', period: '', page: 1})}`) Clear filters
+      if search || status || periodId || signal
+        a.btn-outline(href=`/admin/members${qs({search: '', status: '', period: '', signal: '', page: 1})}`) Clear filters
     .toolbar-actions
       a.btn(href="/admin/members/new") + New Member
       a.btn-outline(href=`/admin/members/export${qs({})}`) Export CSV
@@ -56,6 +61,8 @@ block content
           th Type
           +sortTh('status', 'Status')
           +sortTh('year', 'Year')
+          if view === 'needs-attention'
+            th Signals
           th Actions
       tbody
         each m in members
@@ -70,6 +77,10 @@ block content
                 |
                 span.badge.badge-lifetime Lifetime
             td= m.membership_year
+            if view === 'needs-attention'
+              td
+                each s in (m.attention_signals || [])
+                  span.badge.badge-attention(title=s.label)= s.short
             td
               a.btn-sm(href=`/admin/members/${m.id}`) Edit
 
@@ -81,7 +92,9 @@ block content
         if page < totalPages
           a(href=`/admin/members${qs({page: page + 1})}`) Next &raquo;
   else
-    if view !== 'all' || search || periodId
+    if view === 'needs-attention' && !search && !status && !periodId && !signal
+      p.text-muted No members need attention right now.
+    else if view !== 'all' || search || status || periodId || signal
       p.text-muted No members match this view or search.
     else
       p.text-muted No members found.

--- a/views/admin/settings.pug
+++ b/views/admin/settings.pug
@@ -87,6 +87,21 @@ block content
       input#renewal_reminder_days_before(type="number" name="renewal_reminder_days_before" value=(site.renewal_reminder_days_before || '30') min="1" max="365")
       p.text-muted Members with expiry dates within this many days will be included in renewal reminder sends.
 
+    h3 Needs Attention
+    p.text-muted These thresholds control which members appear under the Needs attention filter on the Members page.
+    .form-group
+      label(for="attention_reminder_count") Reminders Before Flagging
+      input#attention_reminder_count(type="number" name="attention_reminder_count" value=(site.attention_reminder_count || '2') min="1" max="20")
+      p.text-muted Flag a member once they have received this many renewal reminders without renewing. Lower this to widen the list.
+    .form-group
+      label(for="attention_pending_payment_hours") Unfinished Checkout Age (hours)
+      input#attention_pending_payment_hours(type="number" name="attention_pending_payment_hours" value=(site.attention_pending_payment_hours || '24') min="1" max="720")
+      p.text-muted How long a payment may sit unfinished before it counts as abandoned. Raise this to stop flagging people who are still mid-checkout.
+    .form-group
+      label(for="attention_lookback_days") Lookback Window (days)
+      input#attention_lookback_days(type="number" name="attention_lookback_days" value=(site.attention_lookback_days || '180') min="1" max="3650")
+      p.text-muted Only problems from the last this-many days are flagged, so the list stays an outreach queue rather than the full history.
+
     h3 Social Media
     .form-group
       label(for="social_facebook_url") Facebook Page URL


### PR DESCRIPTION
## Summary
The Membership Coordinator had no way to find members who tried to join or renew and did not finish. A signup that died at Stripe looked identical to one created five minutes ago, and a renewal reminder that landed in spam left no visible trace.

Adds a Needs attention view pill to /admin/members that surfaces those members, badges each row with which problem fired, narrows to a single signal, and exports to CSV as an outreach call list.

Seven signals in db/repos/memberAttention.js: repeated reminders with no renewal, Stripe payment failure, unfinished checkout, signup that never reached checkout, duplicate pending signup, failed email send, and lapsed with an unused renewal link. Thresholds are configurable via three new attention_* settings.

Filtering and per-row attribution deliberately run as two passes over the same predicate text. members.search() shares one param array between its COUNT and SELECT, so adding select-list columns there would desync the count; reusing the predicates guarantees a badge cannot disagree with the filter that produced the row.

Also adds Stripe failure webhook handling. payments.status allowed 'failed' but no code path ever wrote it, so the payment signals had no data source at all. checkout.session.expired and payment_intent.payment_failed are now handled, both idempotent on redelivery, with the reason kept in a new payments.failure_reason column. Session creation copies metadata onto the PaymentIntent, without which a decline cannot be attributed to a member.

Three definitions of "already paid up" were tried against production data before settling on enrollment in the current membership period:

  - status != 'active' is unusable, because nothing in this codebase writes status = 'expired'. Lapsed members keep status = 'active', so this would have excluded exactly the people the renewal signals exist to find.
  - The derived good-standing test used by the active viewClause dropped 106 of 172 active members: most of the membership has a null expiry_date predating expiry tracking, and expiry_date records the season last paid for, so it can sit in the future while the member owes for the season now open.
  - A membership_years row for the current period is written only by a successful payment webhook, making it the authoritative record.

email_send_failed carries two guards added after it misfired on production data. The to_email fallback exists because otp and contact rows carry a null member_id, but family sub-members share the primary's address, so an unattributed failure badged an entire family; the fallback is now restricted to primaries. And a later successful send to the same address now clears the failure, so one provider-level outage no longer badges members for the whole lookback window.

Verified with ./scripts/check.sh (lint, Jest 699, Robot 87) plus a manual PostgreSQL check against Render, since neither test layer exercises pg-translate.

Deploy step: checkout.session.expired and payment_intent.payment_failed must be subscribed on the Stripe webhook endpoint, or the Payment failed badge stays permanently empty.

## Checklist
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] No `.env` or secrets committed
