### PR TITLE
Feat/91 renewal link generation

### DIFF
--- a/middleware/locals.js
+++ b/middleware/locals.js
@@ -12,9 +12,14 @@ async function injectLocals(req, res, next) {
     // Flash messages
     res.locals.flash_success = req.session && req.session.flash_success;
     res.locals.flash_error = req.session && req.session.flash_error;
+    // A generated renewal link, carried as {url, expiresAt} so the member page can render it
+    // in a copyable field. One-shot like the other flashes — it is a freshly minted credential,
+    // so it should not linger on the page after the admin navigates away.
+    res.locals.flash_renewal_link = (req.session && req.session.flash_renewal_link) || null;
     if (req.session) {
       delete req.session.flash_success;
       delete req.session.flash_error;
+      delete req.session.flash_renewal_link;
     }
 
     // hCaptcha site key (empty string when not configured — widget is hidden)

--- a/robot/tests/admin_members.robot
+++ b/robot/tests/admin_members.robot
@@ -38,6 +38,20 @@ View Member Details
     Get Text    .detail-table    contains    view@example.com
     Get Text    .detail-table    contains    YSH-2026-9001
 
+Generate Renewal Link
+    [Documentation]    Clicks the real button rather than posting to the route directly. The copy
+    ...    control is wired in public/js/admin.js because helmet's script-src-attr 'none' kills
+    ...    inline handlers silently, so only a real click proves the panel works.
+    ${id}=    Seed Member    first_name=Rita    last_name=Renewer    email=rita@example.com
+    Login As Admin
+    Navigate To    /admin/members/${id}
+    Click    button >> text=Generate Renewal Link
+    Flash Success Should Be Visible    Renewal link generated
+    Wait For Elements State    input#renewal-link    visible    timeout=10s
+    ${url}=    Get Property    input#renewal-link    value
+    Should Match Regexp    ${url}    /renew/[a-f0-9]{64}$
+    Wait For Elements State    button#copy-renewal-link    visible    timeout=10s
+
 Delete Member
     ${id}=    Seed Member    first_name=Delete    last_name=Me    email=delete@example.com
     Login As Admin

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -619,6 +619,33 @@ router.post('/members/:id/send-renewal', async (req, res) => {
   res.redirect(`/admin/members/${req.params.id}`);
 });
 
+// --- Generate Renewal Link ---
+// Same token step as send-renewal, but hands the link back to the admin instead of emailing it —
+// for the member whose email is bouncing or who is on the phone right now.
+router.post('/members/:id/renewal-link', async (req, res) => {
+  const member = await memberRepo.findById(req.params.id);
+  if (!member) {
+    req.session.flash_error = 'Member not found.';
+    return res.redirect('/admin/members');
+  }
+  try {
+    const renewalService = require('../services/renewal');
+    const token = await renewalService.generateRenewalToken(member.id);
+    // generateRenewalToken returns only the token; re-read for the expiry it just wrote.
+    const updated = await memberRepo.findById(member.id);
+    req.session.flash_renewal_link = {
+      url: `${campaignsService.resolveBaseUrl()}/renew/${token}`,
+      expiresAt: updated.renewal_token_expires_at,
+    };
+    (req.logger || logger).info('Renewal link generated', {memberId: member.id});
+    req.session.flash_success = `Renewal link generated for ${member.first_name} ${member.last_name}.`;
+  } catch (e) {
+    (req.logger || logger).error('Renewal link generation failed', {error: e.message, stack: e.stack, memberId: member.id});
+    req.session.flash_error = 'Failed to generate renewal link: ' + e.message;
+  }
+  res.redirect(`/admin/members/${req.params.id}`);
+});
+
 // --- Offline Payment ---
 router.post('/members/:id/payments', async (req, res) => {
   const member = await memberRepo.findById(req.params.id);

--- a/test/routes/admin-renewal-link-http.test.js
+++ b/test/routes/admin-renewal-link-http.test.js
@@ -88,6 +88,13 @@ describe('POST /admin/members/:id/renewal-link', () => {
     expect(page.text).toContain('Renewal Link');
   });
 
+  test('the button opts into the spinner — the round trip is not instant', async () => {
+    // Asserted on the markup rather than in the browser: the form submits and navigates, so the
+    // spinner state is too short-lived to catch reliably from a Robot test.
+    const page = await agent.get(`/admin/members/${member.id}`).expect(200);
+    expect(page.text).toMatch(/renewal-link"[^>]*data-spinner=/);
+  });
+
   test('the link is one-shot — a later page load does not show it again', async () => {
     await generateLink(agent, member.id);
     await agent.get(`/admin/members/${member.id}`).expect(200);

--- a/test/routes/admin-renewal-link-http.test.js
+++ b/test/routes/admin-renewal-link-http.test.js
@@ -1,0 +1,146 @@
+/**
+ * HTTP integration test for the Generate Renewal Link admin action: the real Express app,
+ * real session + CSRF middleware, a real admin login and real Pug rendering. Only the
+ * database is swapped for the in-memory SQLite proxy.
+ */
+process.env.NODE_ENV = 'test';
+
+jest.mock('../../db/database', () => require('../helpers/setupDb'));
+jest.mock('../../services/email', () => ({
+  sendOtpEmail: jest.fn().mockResolvedValue({}),
+}));
+
+const request = require('supertest');
+const app = require('../../server');
+const db = require('../../db/database');
+const { insertMember, insertAdmin } = require('../helpers/fixtures');
+
+const TEST_OTP = '000000';
+
+function tokenFrom(html) {
+  // Admin pages carry the token in a meta tag; public/js/admin.js injects it into POST
+  // forms in the browser, so the rendered form markup has no hidden input of its own.
+  const match = html.match(/name="_csrf" value="([^"]+)"/)
+    || html.match(/name="csrf-token" content="([^"]+)"/);
+  if (!match) throw new Error('No CSRF token in response');
+  return match[1];
+}
+
+async function loginAsAdmin(email) {
+  const agent = request.agent(app);
+  const loginPage = await agent.get('/admin/login').expect(200);
+  await agent.post('/admin/login')
+    .type('form')
+    .send({ _csrf: tokenFrom(loginPage.text), email })
+    .expect(302);
+  const verifyPage = await agent.get('/admin/login/verify').expect(200);
+  await agent.post('/admin/login/verify')
+    .type('form')
+    .send({ _csrf: tokenFrom(verifyPage.text), code: TEST_OTP })
+    .expect(302);
+  return agent;
+}
+
+/** POSTs the action for a member, fetching a fresh CSRF token from their detail page. */
+async function generateLink(agent, memberId) {
+  const page = await agent.get(`/admin/members/${memberId}`).expect(200);
+  return agent.post(`/admin/members/${memberId}/renewal-link`)
+    .type('form')
+    .send({ _csrf: tokenFrom(page.text) });
+}
+
+async function memberRow(id) {
+  return db.get('SELECT * FROM members WHERE id = ?', id);
+}
+
+let agent;
+let member;
+
+beforeEach(async () => {
+  db.__resetTestDb();
+  insertAdmin(db, { email: 'admin@ysh.test' });
+  agent = await loginAsAdmin('admin@ysh.test');
+  member = insertMember(db, { email: 'renewer@t.com', first_name: 'Rita', last_name: 'Renewer' });
+});
+
+describe('POST /admin/members/:id/renewal-link', () => {
+  test('mints a token and redirects back to the member page', async () => {
+    const res = await generateLink(agent, member.id);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe(`/admin/members/${member.id}`);
+
+    const row = await memberRow(member.id);
+    expect(row.renewal_token).toMatch(/^[a-f0-9]{64}$/);
+
+    // 30 days out, give or take the time the request took.
+    const msOut = new Date(row.renewal_token_expires_at).getTime() - Date.now();
+    expect(msOut).toBeGreaterThan(29 * 24 * 60 * 60 * 1000);
+    expect(msOut).toBeLessThan(31 * 24 * 60 * 60 * 1000);
+  });
+
+  test('renders the link in a copyable field on the next page load', async () => {
+    await generateLink(agent, member.id);
+    const row = await memberRow(member.id);
+
+    const page = await agent.get(`/admin/members/${member.id}`).expect(200);
+    expect(page.text).toContain(`/renew/${row.renewal_token}`);
+    expect(page.text).toContain('data-copy="#renewal-link"');
+    expect(page.text).toContain('Renewal Link');
+  });
+
+  test('the link is one-shot — a later page load does not show it again', async () => {
+    await generateLink(agent, member.id);
+    await agent.get(`/admin/members/${member.id}`).expect(200);
+
+    const second = await agent.get(`/admin/members/${member.id}`).expect(200);
+    expect(second.text).not.toContain('data-copy="#renewal-link"');
+  });
+
+  test('reuses a still-valid token so an already-emailed link keeps working', async () => {
+    await generateLink(agent, member.id);
+    const first = await memberRow(member.id);
+
+    await generateLink(agent, member.id);
+    const second = await memberRow(member.id);
+
+    expect(second.renewal_token).toBe(first.renewal_token);
+    // Same token, but the clock is pushed back out.
+    expect(new Date(second.renewal_token_expires_at).getTime())
+      .toBeGreaterThanOrEqual(new Date(first.renewal_token_expires_at).getTime());
+  });
+
+  test('the generated link opens the public renewal form', async () => {
+    await generateLink(agent, member.id);
+    const row = await memberRow(member.id);
+
+    // A fresh agent — the member is not logged in as an admin.
+    await request(app).get(`/renew/${row.renewal_token}`).expect(200);
+  });
+
+  test('an unknown member redirects to the members list', async () => {
+    const page = await agent.get(`/admin/members/${member.id}`).expect(200);
+    const res = await agent.post('/admin/members/999999/renewal-link')
+      .type('form')
+      .send({ _csrf: tokenFrom(page.text) });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/admin/members');
+  });
+
+  test('rejects a request with no admin session', async () => {
+    // A real CSRF token from the (unauthenticated) login page, so the request gets past the
+    // token check and is turned away by requireAdmin rather than by CSRF.
+    const anon = request.agent(app);
+    const loginPage = await anon.get('/admin/login').expect(200);
+
+    const res = await anon.post(`/admin/members/${member.id}/renewal-link`)
+      .type('form')
+      .send({ _csrf: tokenFrom(loginPage.text) });
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toMatch(/\/admin\/login/);
+
+    const row = await memberRow(member.id);
+    expect(row.renewal_token).toBeFalsy();
+  });
+});

--- a/user_guide/02-managing-members.md
+++ b/user_guide/02-managing-members.md
@@ -89,6 +89,18 @@ they can renew.
 
 See [Email System](06-email-system.md) for bulk and individual renewal reminder workflows.
 
+### Generating a Renewal Link
+
+**Generate Renewal Link** on a member's page gives you their renewal link directly, without sending anything. Use it
+when email isn't the right channel — you have them on the phone, you're texting them, or their address is bouncing.
+Click it, then use **Copy link** to put the URL on your clipboard.
+
+The link goes straight to the renewal form with their details already filled in, so it is specific to that one member —
+don't post it publicly or forward it to anyone else. It works for 30 days. Generating a link does not invalidate one you
+emailed earlier; it hands back the same link and resets the 30 days.
+
+The link only shows once. Leave the page and it's gone — click the button again to get it back.
+
 ## Needs Attention
 
 This is the outreach list. It collects members who look like they *meant* to join or renew but didn't finish — the
@@ -118,6 +130,10 @@ Click the **Needs attention** pill. Each row is badged with the problem or probl
 
 Hover a badge to see a longer description. A member can carry more than one badge — someone who signed up twice and had
 a card declined shows both.
+
+Most of these say "call" or "text," which raises the obvious question of what to send them once you have them. Open the
+member and use [Generate Renewal Link](#generating-a-renewal-link) — that gives you a link you can read out or text,
+which is the whole point for the members whose email clearly isn't reaching them.
 
 ### Working the list
 

--- a/views/admin/members/view.pug
+++ b/views/admin/members/view.pug
@@ -77,11 +77,24 @@ block content
         if !member.primary_member_id
           form(method="POST" action=`/admin/members/${member.id}/send-renewal` style="display:inline" data-confirm=`Send renewal reminder to ${member.first_name} ${member.last_name}?`)
             button.btn-outline(type="submit") Send Renewal Reminder
+          form(method="POST" action=`/admin/members/${member.id}/renewal-link` style="display:inline")
+            button.btn-outline(type="submit") Generate Renewal Link
         if member.membership_type !== 'family' && !member.primary_member_id
           form(method="POST" action=`/admin/members/${member.id}/upgrade-to-family` style="display:inline" data-confirm=`Upgrade ${member.first_name} ${member.last_name} to a family membership?`)
             button.btn-outline(type="submit") Upgrade to Family
         form(method="POST" action=`/admin/members/${member.id}/delete` style="display:inline" data-confirm="Delete this member?")
           button.btn-danger(type="submit") Delete
+
+    if flash_renewal_link
+      .admin-panel
+        h3 Renewal Link
+        p.text-muted Read this out over the phone or paste it into a text. It goes straight to the renewal form — no email is sent.
+        .form-group
+          input#renewal-link(type="text" value=flash_renewal_link.url readonly style="font-family: monospace;")
+          .form-actions(style="margin-top: 0.5rem;")
+            button#copy-renewal-link.btn-outline(type="button" data-copy="#renewal-link") Copy link
+            a.btn-outline(href=flash_renewal_link.url target="_blank" rel="noopener" style="margin-left: 0.5rem;") Open
+          p.text-muted(style="margin-top: 0.5rem;") Expires #{formatDate(flash_renewal_link.expiresAt)}
 
     .admin-panel
       h3 Membership Cards

--- a/views/admin/members/view.pug
+++ b/views/admin/members/view.pug
@@ -77,7 +77,7 @@ block content
         if !member.primary_member_id
           form(method="POST" action=`/admin/members/${member.id}/send-renewal` style="display:inline" data-confirm=`Send renewal reminder to ${member.first_name} ${member.last_name}?`)
             button.btn-outline(type="submit") Send Renewal Reminder
-          form(method="POST" action=`/admin/members/${member.id}/renewal-link` style="display:inline")
+          form(method="POST" action=`/admin/members/${member.id}/renewal-link` style="display:inline" data-spinner="Generating…")
             button.btn-outline(type="submit") Generate Renewal Link
         if member.membership_type !== 'family' && !member.primary_member_id
           form(method="POST" action=`/admin/members/${member.id}/upgrade-to-family` style="display:inline" data-confirm=`Upgrade ${member.first_name} ${member.last_name} to a family membership?`)


### PR DESCRIPTION
## Summary
Adds ability to generate renewal link on member records.

## Checklist
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] No `.env` or secrets committed
