### PR TITLE
Sync members to Sender.net groups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,12 @@ STRIPE_WEBHOOK_SECRET=whsec_...
 MAILERSEND_API_KEY=mlsn...
 FROM_EMAIL=noreply@yellowstoneseahawkers.com
 
+# Sender.net (optional — member list sync is skipped entirely if unset)
+# Group IDs come from GET https://api.sender.net/v2/groups
+SENDER_API_TOKEN=
+SENDER_GROUP_CURRENT=
+SENDER_GROUP_LAPSED=
+
 # hCaptcha
 HCAPTCHA_SITE_KEY=
 HCAPTCHA_SECRET_KEY=

--- a/render.yaml
+++ b/render.yaml
@@ -27,6 +27,12 @@ services:
         sync: false
       - key: FROM_EMAIL
         sync: false
+      - key: SENDER_API_TOKEN
+        sync: false
+      - key: SENDER_GROUP_CURRENT
+        sync: false
+      - key: SENDER_GROUP_LAPSED
+        sync: false
       - key: B2_ENDPOINT
         sync: false
       - key: B2_REGION

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -340,15 +340,18 @@ router.post('/members', async (req, res) => {
       });
 
       // Activate all members if status is active
-      if (status === 'active') {
-        const primary = await memberRepo.findByEmail(email);
-        if (primary) {
-          await memberRepo.activate(primary.id);
-          const family = await memberRepo.findFamilyMembers(primary.id);
-          for (const fm of family) {
-            await memberRepo.activate(fm.id);
-          }
+      const primaryRecord = await memberRepo.findByEmail(email);
+      if (status === 'active' && primaryRecord) {
+        await memberRepo.activate(primaryRecord.id);
+        const family = await memberRepo.findFamilyMembers(primaryRecord.id);
+        for (const fm of family) {
+          await memberRepo.activate(fm.id);
         }
+      }
+
+      // Sender only ever sees the primary here — family members share their email.
+      if (primaryRecord) {
+        await require('../services/sender').syncMemberSafe(primaryRecord.id);
       }
 
       const count = familyMembers.length + 1;
@@ -358,12 +361,14 @@ router.post('/members', async (req, res) => {
       const { generateMemberNumber } = require('../services/members');
       const member_number = await generateMemberNumber(year);
 
-      await memberRepo.create({
+      const created = await memberRepo.create({
         member_number, first_name, last_name, email, phone,
         address_street, address_city, address_state, address_zip,
         membership_year: year, join_date: normalizedJoinDate, status: status || 'pending',
         is_lifetime: req.body.is_lifetime === 'on', notes,
       });
+
+      await require('../services/sender').syncMemberSafe(created.lastInsertRowid);
 
       req.session.flash_success = `Member ${first_name} ${last_name} created.`;
     }
@@ -448,6 +453,8 @@ router.post('/members/:id', async (req, res) => {
       membership_year, join_date: normalizedJoinDate, status,
       is_lifetime: req.body.is_lifetime === 'on', notes,
     });
+    // Propagate status/name changes to Sender. Logs and swallows any Sender failure.
+    await require('../services/sender').syncMemberSafe(req.params.id);
     req.session.flash_success = 'Member updated.';
   } catch (e) {
     req.session.flash_error = e.message;
@@ -460,7 +467,12 @@ router.post('/members/:id/delete', async (req, res) => {
     req.session.flash_error = 'You cannot delete your own account while logged in.';
     return res.redirect(`/admin/members/${req.params.id}`);
   }
+  const doomed = await memberRepo.findById(req.params.id);
   await memberRepo.deleteById(req.params.id);
+  // Drop the address from both Sender groups unless another member still holds it —
+  // otherwise a deleted member keeps receiving newsletters, and no later sync can fix
+  // it because syncAllMembers only ever sees members who still exist.
+  if (doomed) await require('../services/sender').syncEmailSafe(doomed.email);
   req.session.flash_success = 'Member deleted.';
   res.redirect('/admin/members');
 });
@@ -637,6 +649,11 @@ router.post('/members/:id/payments', async (req, res) => {
     });
   }
 
+  // Sync on every recorded payment, not just activations: a renewal for a member who is
+  // already active changes their expiry date, which Sender carries as a custom field.
+  // Family sub-members share the primary's email, so the primary is what Sender sees.
+  await require('../services/sender').syncMemberSafe(member.primary_member_id || member.id);
+
   req.session.flash_success = `Payment of $${dollars.toFixed(2)} recorded.`;
   res.redirect(`/admin/members/${req.params.id}`);
 });
@@ -658,6 +675,7 @@ router.post('/members/:id/upgrade-to-family', async (req, res) => {
   }
   try {
     await memberRepo.upgradeMembershipType(req.params.id, 'family');
+    await require('../services/sender').syncMemberSafe(req.params.id);
     req.session.flash_success = `${member.first_name} ${member.last_name}'s membership upgraded to family.`;
   } catch (e) {
     req.session.flash_error = e.message;
@@ -734,12 +752,16 @@ router.post('/members/:id/family-members/:familyId/remove', async (req, res) => 
     return res.redirect(`/admin/members/${req.params.id}`);
   }
   try {
+    const senderService = require('../services/sender');
     const wouldDelete = await memberRepo.emailConflictsWithPrimary(familyMember.email, familyMember.id);
     if (wouldDelete) {
       await memberRepo.deleteById(req.params.familyId);
+      await senderService.syncEmailSafe(familyMember.email);
       req.session.flash_success = `${familyMember.first_name} ${familyMember.last_name} was deleted — their email (${familyMember.email}) is already used by another primary member.`;
     } else {
       await memberRepo.detachFamilyMember(req.params.familyId);
+      // Now a primary in their own right, and cancelled — belongs in neither group.
+      await senderService.syncMemberSafe(req.params.familyId);
       req.session.flash_success = `${familyMember.first_name} ${familyMember.last_name} removed from family membership and converted to individual.`;
     }
   } catch (e) {

--- a/routes/stripe.js
+++ b/routes/stripe.js
@@ -113,6 +113,13 @@ router.post('/webhook', async (req, res) => {
       } catch (e) {
         logger.error('Email send error', { error: e.message, stack: e.stack });
       }
+
+      // 7. Push to Sender. Last, and non-throwing — a Sender outage must never fail a
+      //    paid signup. Covers renewals too; they land on this same webhook. One call
+      //    per unique email: family sub-members share the primary's address, and
+      //    Sender keys on email, so syncing each would clobber the primary's name.
+      const senderService = require('../services/sender');
+      await senderService.syncMembersSafe(allMembers);
     }
   }
 

--- a/scripts/sync-sender.js
+++ b/scripts/sync-sender.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+'use strict';
+
+require('dotenv').config();
+
+const migrate = require('../db/migrate');
+const db = require('../db/database');
+const senderService = require('../services/sender');
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+async function main() {
+  if (DRY_RUN) console.log('=== DRY RUN — no Sender writes will occur ===\n');
+
+  if (!senderService.isConfigured()) {
+    console.error('Sender is not configured. Set SENDER_API_TOKEN, SENDER_GROUP_CURRENT and SENDER_GROUP_LAPSED.');
+    process.exit(1);
+  }
+
+  await migrate();
+
+  const stats = await senderService.syncAllMembers({ dryRun: DRY_RUN });
+
+  console.log('\n=== Summary ===');
+  console.log(`  Unique emails:   ${stats.total}`);
+  console.log(`  Synced:          ${stats.synced}`);
+  console.log(`  Failed:          ${stats.failed}`);
+  console.log(`  → Current group: ${stats.groups.current}`);
+  console.log(`  → Lapsed group:  ${stats.groups.lapsed}`);
+  console.log(`  → No group:      ${stats.groups.removed}`);
+  if (DRY_RUN) console.log('\n(dry run — nothing was sent to Sender)');
+}
+
+main()
+  .catch(err => {
+    console.error('Fatal:', err.message, err.stack);
+    process.exit(1);
+  })
+  .finally(() => db.close());

--- a/services/sender.js
+++ b/services/sender.js
@@ -1,0 +1,450 @@
+const membersRepo = require('../db/repos/members');
+const logger = require('./logger');
+
+const API_BASE = 'https://api.sender.net/v2';
+const REQUIRED_VARS = ['SENDER_API_TOKEN', 'SENDER_GROUP_CURRENT', 'SENDER_GROUP_LAPSED'];
+
+// Sender rejects very large group payloads; chunk bulk add/remove calls.
+const GROUP_CHUNK_SIZE = 500;
+
+// Retry policy for 429 / 5xx (Sender's docs recommend exponential backoff).
+const BASE_BACKOFF_MS = 1000;
+
+// Two profiles. BACKGROUND is for the CLI backfill, where waiting out a rate-limit
+// window is the right call. REQUEST is for anything inside an HTTP handler: a Stripe
+// webhook that blocks for minutes gets re-delivered by Stripe, which re-runs payment
+// completion and re-sends welcome/card emails — a duplicated signup is worse than a
+// missed sync. A miss is only repaired by the next run of `scripts/sync-sender.js`,
+// which nothing schedules yet, so it has to be run periodically by hand.
+const BACKGROUND_RETRY = { maxAttempts: 5, maxBackoffMs: 60000 };
+const REQUEST_RETRY = { maxAttempts: 2, maxBackoffMs: 1000 };
+
+// When fewer than this many requests remain in the rate-limit window, wait it out.
+const RATE_LIMIT_FLOOR = 2;
+
+function isConfigured() {
+  return REQUIRED_VARS.every((v) => process.env[v]);
+}
+
+function currentGroupId() {
+  return process.env.SENDER_GROUP_CURRENT;
+}
+
+function lapsedGroupId() {
+  return process.env.SENDER_GROUP_LAPSED;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function backoffMs(attempt, maxBackoffMs) {
+  return Math.min(BASE_BACKOFF_MS * Math.pow(2, attempt - 1), maxBackoffMs);
+}
+
+// Sender returns `Retry-After` in seconds on 429; fall back to exponential backoff.
+function retryAfterMs(res, attempt, maxBackoffMs) {
+  const header = res.headers && res.headers.get ? res.headers.get('Retry-After') : null;
+  const seconds = parseInt(header, 10);
+  if (Number.isFinite(seconds) && seconds > 0) return Math.min(seconds * 1000, maxBackoffMs);
+  return backoffMs(attempt, maxBackoffMs);
+}
+
+/**
+ * How long until the rate-limit window resets, in ms.
+ *
+ * Sender sends X-RateLimit-Reset as a bare integer, so Date.parse() on it is always
+ * NaN — the header has to be read numerically. It is epoch seconds in practice, but
+ * accept epoch ms and plain seconds-remaining too rather than silently mis-waiting.
+ */
+function rateLimitResetMs(header) {
+  const value = parseInt(header, 10);
+  if (!Number.isFinite(value) || value <= 0) return null;
+  if (value > 1e12) return value - Date.now();            // epoch milliseconds
+  if (value > 1e9) return value * 1000 - Date.now();      // epoch seconds
+  return value * 1000;                                     // seconds remaining
+}
+
+// Sender's rate limit is per account per minute. When the window is nearly spent,
+// pause until X-RateLimit-Reset rather than burning a 429.
+async function respectRateLimit(res, { maxBackoffMs }) {
+  if (!res.headers || !res.headers.get) return;
+  const remaining = parseInt(res.headers.get('X-RateLimit-Remaining'), 10);
+  if (!Number.isFinite(remaining) || remaining > RATE_LIMIT_FLOOR) return;
+
+  const resetMs = rateLimitResetMs(res.headers.get('X-RateLimit-Reset'));
+  const waitMs = resetMs === null ? BASE_BACKOFF_MS : resetMs;
+  if (waitMs > 0) {
+    logger.info('Sender rate limit nearly exhausted, pausing', { remaining, waitMs });
+    await sleep(Math.min(waitMs, maxBackoffMs));
+  }
+}
+
+/**
+ * Single Sender API call with retry on 429 and 5xx.
+ * Resolves to { ok, status, body }; never throws on an HTTP error status, so callers
+ * can branch on `status` (the create → update fallback needs this).
+ */
+async function senderRequest(method, path, body, retry = BACKGROUND_RETRY) {
+  const { maxAttempts, maxBackoffMs } = retry;
+  let lastError = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let res;
+    try {
+      res = await fetch(`${API_BASE}${path}`, {
+        method,
+        headers: {
+          'Content-Type': 'application/json',
+          'Accept': 'application/json',
+          'Authorization': `Bearer ${process.env.SENDER_API_TOKEN}`,
+        },
+        body: body === undefined ? undefined : JSON.stringify(body),
+      });
+    } catch (err) {
+      // Network-level failure — retry.
+      lastError = err;
+      if (attempt === maxAttempts) throw err;
+      await sleep(backoffMs(attempt, maxBackoffMs));
+      continue;
+    }
+
+    if (res.status === 429 || res.status >= 500) {
+      if (attempt === maxAttempts) {
+        const parsed = await res.json().catch(() => ({}));
+        return { ok: false, status: res.status, body: parsed };
+      }
+      const wait = res.status === 429
+        ? retryAfterMs(res, attempt, maxBackoffMs)
+        : backoffMs(attempt, maxBackoffMs);
+      logger.warn('Sender request retrying', { method, path, status: res.status, attempt, wait });
+      await sleep(wait);
+      continue;
+    }
+
+    await respectRateLimit(res, retry);
+
+    const parsed = await res.json().catch(() => ({}));
+    return { ok: res.ok, status: res.status, body: parsed };
+  }
+
+  throw lastError || new Error('Sender request failed');
+}
+
+function errorMessage(result) {
+  const body = result.body || {};
+  if (body.message && typeof body.message === 'string') return body.message;
+  if (body.errors) return JSON.stringify(body.errors);
+  return `HTTP ${result.status}`;
+}
+
+function normalizeEmail(email) {
+  return (email || '').trim().toLowerCase();
+}
+
+function isoDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/**
+ * Which Sender group a member belongs in, or null if they belong in none
+ * (pending members never paid; cancelled members opted out).
+ *
+ * Lapsed has to be *derived*, not read off `status`: nothing in the app ever writes
+ * status='expired' (only an admin picking it by hand does), so a membership that simply
+ * runs out keeps status='active' with a past expiry_date. This mirrors the expired
+ * predicate the member list uses — see the status filter in db/repos/members.js.
+ *
+ * There is deliberately no "all members" group — Sender's subscriber list already
+ * is that, so a campaign to everyone needs no group at all.
+ */
+function groupForMember(member, today = isoDate()) {
+  if (member.status === 'pending' || member.status === 'cancelled') return null;
+  if (member.is_lifetime) return currentGroupId();
+  if (member.status === 'expired') return lapsedGroupId();
+  if (member.expiry_date && member.expiry_date < today) return lapsedGroupId();
+  return member.status === 'active' ? currentGroupId() : null;
+}
+
+function buildSubscriber(member) {
+  return {
+    email: normalizeEmail(member.email),
+    firstname: member.first_name || '',
+    lastname: member.last_name || '',
+    fields: {
+      '{$member_number}': member.member_number || '',
+      '{$membership_expires}': member.expiry_date || '',
+    },
+    // Never fire Sender automations from a sync — especially not during a backfill.
+    trigger_automation: false,
+  };
+}
+
+/**
+ * Create the subscriber, falling back to update when Sender says it already exists.
+ * `groups` is deliberately never sent: on Sender it *replaces* group assignment, which
+ * would wipe any group a human curated by hand. Groups are reconciled separately.
+ */
+async function upsertSubscriber(member, retry = BACKGROUND_RETRY) {
+  const payload = buildSubscriber(member);
+  const created = await senderRequest('POST', '/subscribers', payload, retry);
+  if (created.ok) return created;
+
+  // 409/422 both signal "this email is already a subscriber" depending on plan.
+  if (created.status === 409 || created.status === 422) {
+    const updated = await senderRequest(
+      'PATCH',
+      `/subscribers/${encodeURIComponent(payload.email)}`,
+      payload,
+      retry
+    );
+    if (updated.ok) return updated;
+    throw new Error(errorMessage(updated));
+  }
+
+  throw new Error(errorMessage(created));
+}
+
+function chunk(items, size) {
+  const out = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+async function addToGroup(groupId, emails, retry = BACKGROUND_RETRY) {
+  for (const batch of chunk(emails, GROUP_CHUNK_SIZE)) {
+    const result = await senderRequest('POST', `/subscribers/groups/${groupId}`, { subscribers: batch }, retry);
+    if (!result.ok) throw new Error(errorMessage(result));
+  }
+}
+
+async function removeFromGroup(groupId, emails, retry = BACKGROUND_RETRY) {
+  for (const batch of chunk(emails, GROUP_CHUNK_SIZE)) {
+    const result = await senderRequest('DELETE', `/subscribers/groups/${groupId}`, { subscribers: batch }, retry);
+    if (!result.ok) throw new Error(errorMessage(result));
+  }
+}
+
+// Removing a subscriber from a group they were never in is the normal case, and Sender
+// reports it as an error; never let that abandon the rest of a reconciliation.
+async function removeFromGroupQuietly(groupId, emails, retry = BACKGROUND_RETRY) {
+  if (!emails.length) return;
+  try {
+    await removeFromGroup(groupId, emails, retry);
+  } catch (e) {
+    logger.warn('Sender group removal failed', { groupId, count: emails.length, error: e.message });
+  }
+}
+
+/**
+ * Sync one member: upsert the subscriber, then put them in exactly the right group.
+ * Removing from the other group is what makes a status change (active → expired) stick.
+ *
+ * The add runs before the removes, and a failed remove is logged rather than thrown:
+ * removing a subscriber from a group they were never in is the common case, and if
+ * Sender rejects it we still want the member to have landed in the right group.
+ */
+async function syncMember(memberId, retry = BACKGROUND_RETRY) {
+  if (!isConfigured()) return { skipped: true };
+
+  const member = await membersRepo.findById(memberId);
+  if (!member) throw new Error(`Member ${memberId} not found`);
+  if (!normalizeEmail(member.email)) throw new Error(`Member ${memberId} has no email`);
+
+  await upsertSubscriber(member, retry);
+
+  const email = normalizeEmail(member.email);
+  const target = groupForMember(member);
+
+  if (target) await addToGroup(target, [email], retry);
+
+  for (const groupId of [currentGroupId(), lapsedGroupId()]) {
+    if (groupId === target) continue;
+    await removeFromGroupQuietly(groupId, [email], retry);
+  }
+
+  return { skipped: false, email, group: target };
+}
+
+/**
+ * Wrapper for request handlers: logs and swallows everything, so a Sender outage can
+ * never fail a paid signup or an admin save. Uses the short REQUEST_RETRY budget so a
+ * slow Sender can't hold an HTTP response open long enough for the caller to time out.
+ */
+async function syncMemberSafe(memberId) {
+  if (!isConfigured()) return;
+  try {
+    await syncMember(memberId, REQUEST_RETRY);
+  } catch (e) {
+    logger.error('Sender sync failed for member', { memberId, error: e.message });
+  }
+}
+
+/**
+ * Sync a set of members touched by one request (a family signup, say), collapsing
+ * shared email addresses first. Family sub-members carry the primary's email, so
+ * syncing them individually would overwrite the primary's name in Sender with a
+ * sub-member's.
+ */
+async function syncMembersSafe(members) {
+  if (!isConfigured()) return;
+
+  let targets = [];
+  try {
+    targets = dedupeByEmail((members || []).filter(Boolean));
+  } catch (e) {
+    // Nothing here may escape: this runs inside the Stripe webhook, and a throw there
+    // means Stripe re-delivers the event and the signup is processed twice.
+    logger.error('Sender member dedupe failed', { error: e.message });
+    return;
+  }
+
+  for (const member of targets) {
+    await syncMemberSafe(member.id);
+  }
+}
+
+/**
+ * Reconcile one email address after the member behind it is gone or renamed.
+ *
+ * If any member still holds the address (a family primary whose sub-member was
+ * deleted, say) it is re-synced from that member; otherwise the address is dropped
+ * from both groups so a deleted member stops receiving club mail. The subscriber
+ * itself is left in Sender — this integration never deletes subscribers.
+ */
+async function syncEmailSafe(email) {
+  if (!isConfigured()) return;
+
+  const normalized = normalizeEmail(email);
+  if (!normalized) return;
+
+  try {
+    // members.email is stored as typed, so look up the raw address before the
+    // lowercased one (the DB lookup is case-sensitive; Sender's keying is not).
+    const holder = await membersRepo.findByEmail(email)
+      || (email !== normalized ? await membersRepo.findByEmail(normalized) : null);
+    if (holder) {
+      await syncMember(holder.id, REQUEST_RETRY);
+      return;
+    }
+    for (const groupId of [currentGroupId(), lapsedGroupId()]) {
+      await removeFromGroupQuietly(groupId, [normalized], REQUEST_RETRY);
+    }
+  } catch (e) {
+    logger.error('Sender sync failed for email', { email: normalized, error: e.message });
+  }
+}
+
+/**
+ * Collapse members to one record per email address.
+ *
+ * members.email is only unique among primaries (see the partial index in db/schema.js);
+ * family sub-members routinely share the primary's address. Sender keys on email, so
+ * without this the family row would overwrite the primary's name and status.
+ */
+function dedupeByEmail(members) {
+  const byEmail = new Map();
+  for (const member of members) {
+    const email = normalizeEmail(member.email);
+    if (!email) continue;
+
+    const existing = byEmail.get(email);
+    if (!existing) {
+      byEmail.set(email, member);
+      continue;
+    }
+    // Primary wins over a sub-member sharing the address.
+    const existingIsPrimary = existing.primary_member_id == null;
+    const candidateIsPrimary = member.primary_member_id == null;
+    if (candidateIsPrimary && !existingIsPrimary) byEmail.set(email, member);
+
+    // Two unrelated primaries can still collide here: the DB's unique index on
+    // members.email is case-sensitive, Sender's keying is not. One of them loses their
+    // name and member number in Sender, so say which.
+    if (candidateIsPrimary && existingIsPrimary) {
+      logger.warn('Two primary members share one Sender address; keeping the first', {
+        email, kept: existing.id, dropped: member.id,
+      });
+    }
+  }
+  return [...byEmail.values()];
+}
+
+/**
+ * Full backfill. Phase A upserts every subscriber one at a time (Sender has no bulk
+ * create); Phase B reconciles group membership in a handful of bulk calls.
+ */
+async function syncAllMembers({ dryRun = false } = {}) {
+  if (!isConfigured()) {
+    throw new Error(`Sender is not configured — set ${REQUIRED_VARS.join(', ')}`);
+  }
+
+  const members = dedupeByEmail(await membersRepo.listAll());
+  const stats = {
+    total: members.length,
+    synced: 0,
+    failed: 0,
+    groups: { current: 0, lapsed: 0, removed: 0 },
+  };
+
+  const current = [];
+  const lapsed = [];
+  const ungrouped = [];
+  const today = isoDate();
+
+  for (const member of members) {
+    const email = normalizeEmail(member.email);
+    const target = groupForMember(member, today);
+
+    if (dryRun) {
+      stats.synced++;
+    } else {
+      // Phase A — one call per member, sequential so the rate limiter stays accurate.
+      try {
+        await upsertSubscriber(member);
+        stats.synced++;
+      } catch (e) {
+        logger.error('Sender upsert failed for member', { memberId: member.id, error: e.message });
+        stats.failed++;
+        // Leave them out of the group batches entirely: Sender rejects a whole chunk
+        // over one unknown subscriber, which would take the other 499 down with it.
+        continue;
+      }
+    }
+
+    if (target === currentGroupId()) current.push(email);
+    else if (target === lapsedGroupId()) lapsed.push(email);
+    else ungrouped.push(email);
+  }
+
+  stats.groups.current = current.length;
+  stats.groups.lapsed = lapsed.length;
+  stats.groups.removed = ungrouped.length;
+
+  if (!dryRun) {
+    // Phase B — bulk group reconciliation. Adds first, then removes, and a failed
+    // remove is logged rather than thrown: most of these subscribers were never in the
+    // group being removed from, which Sender reports as an error. Letting that reject
+    // would abandon the rest of the reconciliation half-done.
+    await addToGroup(currentGroupId(), current);
+    await addToGroup(lapsedGroupId(), lapsed);
+    await removeFromGroupQuietly(currentGroupId(), [...lapsed, ...ungrouped]);
+    await removeFromGroupQuietly(lapsedGroupId(), [...current, ...ungrouped]);
+  }
+
+  logger.info('Sender full sync completed', stats);
+  return stats;
+}
+
+module.exports = {
+  isConfigured,
+  groupForMember,
+  buildSubscriber,
+  dedupeByEmail,
+  upsertSubscriber,
+  syncMember,
+  syncMemberSafe,
+  syncMembersSafe,
+  syncEmailSafe,
+  syncAllMembers,
+};

--- a/test/services/sender.test.js
+++ b/test/services/sender.test.js
@@ -1,0 +1,536 @@
+jest.mock('../../db/database', () => require('../helpers/setupDb'));
+
+const db = require('../../db/database');
+const { insertMember } = require('../helpers/fixtures');
+
+let senderService;
+let testDb;
+
+const CURRENT_GROUP = 'grpCUR';
+const LAPSED_GROUP = 'grpLAP';
+
+// Sender responses carry rate-limit headers the service inspects.
+function response({ ok = true, status = 200, body = { success: true }, headers = {} } = {}) {
+  const map = { 'X-RateLimit-Remaining': '50', ...headers };
+  return {
+    ok,
+    status,
+    headers: { get: (k) => (k in map ? map[k] : null) },
+    json: async () => body,
+  };
+}
+
+beforeEach(() => {
+  db.__resetTestDb();
+  jest.clearAllMocks();
+
+  process.env.SENDER_API_TOKEN = 'test-token';
+  process.env.SENDER_GROUP_CURRENT = CURRENT_GROUP;
+  process.env.SENDER_GROUP_LAPSED = LAPSED_GROUP;
+
+  global.fetch = jest.fn().mockResolvedValue(response());
+
+  jest.isolateModules(() => {
+    senderService = require('../../services/sender');
+  });
+
+  testDb = db.__getCurrentDb();
+});
+
+afterEach(() => {
+  delete process.env.SENDER_API_TOKEN;
+  delete process.env.SENDER_GROUP_CURRENT;
+  delete process.env.SENDER_GROUP_LAPSED;
+});
+
+function calls() {
+  return global.fetch.mock.calls.map(([url, opts]) => ({
+    url,
+    method: opts.method,
+    body: opts.body ? JSON.parse(opts.body) : undefined,
+    auth: opts.headers.Authorization,
+  }));
+}
+
+describe('isConfigured', () => {
+  test('is false when the token is missing', () => {
+    delete process.env.SENDER_API_TOKEN;
+    expect(senderService.isConfigured()).toBe(false);
+  });
+
+  test('is false when a group id is missing', () => {
+    delete process.env.SENDER_GROUP_LAPSED;
+    expect(senderService.isConfigured()).toBe(false);
+  });
+
+  test('is true when all vars are set', () => {
+    expect(senderService.isConfigured()).toBe(true);
+  });
+});
+
+describe('groupForMember', () => {
+  test('active members go to the current group', () => {
+    expect(senderService.groupForMember({ status: 'active' })).toBe(CURRENT_GROUP);
+  });
+
+  test('lifetime members are active regardless of status', () => {
+    expect(senderService.groupForMember({ status: 'expired', is_lifetime: 1 })).toBe(CURRENT_GROUP);
+  });
+
+  test('expired members go to the lapsed group', () => {
+    expect(senderService.groupForMember({ status: 'expired' })).toBe(LAPSED_GROUP);
+  });
+
+  // Nothing in the app writes status='expired'; a membership that runs out keeps
+  // status='active' with a past expiry_date, so Lapsed has to be derived from the date.
+  test('an active member whose expiry date has passed is lapsed', () => {
+    expect(
+      senderService.groupForMember({ status: 'active', expiry_date: '2020-03-31' })
+    ).toBe(LAPSED_GROUP);
+  });
+
+  test('an active member whose expiry date is in the future is current', () => {
+    expect(
+      senderService.groupForMember({ status: 'active', expiry_date: '2099-03-31' })
+    ).toBe(CURRENT_GROUP);
+  });
+
+  test('an active member with no expiry date on file is current', () => {
+    expect(senderService.groupForMember({ status: 'active', expiry_date: null })).toBe(CURRENT_GROUP);
+  });
+
+  test('a lifetime member with a stale expiry date is still current', () => {
+    expect(
+      senderService.groupForMember({ status: 'active', expiry_date: '2020-03-31', is_lifetime: 1 })
+    ).toBe(CURRENT_GROUP);
+  });
+
+  test('a cancelled member with a future expiry date still belongs to no group', () => {
+    expect(
+      senderService.groupForMember({ status: 'cancelled', expiry_date: '2099-03-31' })
+    ).toBeNull();
+  });
+
+  test('pending and cancelled members belong to no group', () => {
+    expect(senderService.groupForMember({ status: 'pending' })).toBeNull();
+    expect(senderService.groupForMember({ status: 'cancelled' })).toBeNull();
+  });
+});
+
+describe('buildSubscriber', () => {
+  test('normalizes email and maps custom fields', () => {
+    const payload = senderService.buildSubscriber({
+      email: '  Jane@Example.COM ',
+      first_name: 'Jane',
+      last_name: 'Doe',
+      member_number: 'YSH-2025-0001',
+      expiry_date: '2026-03-31',
+    });
+    expect(payload.email).toBe('jane@example.com');
+    expect(payload.firstname).toBe('Jane');
+    expect(payload.lastname).toBe('Doe');
+    expect(payload.fields['{$member_number}']).toBe('YSH-2025-0001');
+    expect(payload.fields['{$membership_expires}']).toBe('2026-03-31');
+  });
+
+  test('never triggers Sender automations', () => {
+    const payload = senderService.buildSubscriber({ email: 'a@b.com' });
+    expect(payload.trigger_automation).toBe(false);
+  });
+
+  test('omits groups so an existing Sender group is never clobbered', () => {
+    const payload = senderService.buildSubscriber({ email: 'a@b.com' });
+    expect(payload.groups).toBeUndefined();
+  });
+});
+
+describe('dedupeByEmail', () => {
+  test('prefers the primary member when a family shares an email', () => {
+    const result = senderService.dedupeByEmail([
+      { id: 2, email: 'shared@test.com', first_name: 'Kid', primary_member_id: 1, status: 'pending' },
+      { id: 1, email: 'Shared@test.com', first_name: 'Parent', primary_member_id: null, status: 'active' },
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(1);
+    expect(result[0].first_name).toBe('Parent');
+  });
+
+  test('drops members with no email', () => {
+    const result = senderService.dedupeByEmail([
+      { id: 1, email: '', primary_member_id: null },
+      { id: 2, email: null, primary_member_id: null },
+      { id: 3, email: 'ok@test.com', primary_member_id: null },
+    ]);
+    expect(result.map(m => m.id)).toEqual([3]);
+  });
+
+  test('keeps distinct emails', () => {
+    const result = senderService.dedupeByEmail([
+      { id: 1, email: 'a@test.com', primary_member_id: null },
+      { id: 2, email: 'b@test.com', primary_member_id: null },
+    ]);
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe('upsertSubscriber', () => {
+  test('creates via POST /subscribers with a bearer token', async () => {
+    await senderService.upsertSubscriber({ email: 'new@test.com', first_name: 'New', last_name: 'Guy' });
+
+    const [call] = calls();
+    expect(call.method).toBe('POST');
+    expect(call.url).toBe('https://api.sender.net/v2/subscribers');
+    expect(call.auth).toBe('Bearer test-token');
+    expect(call.body.email).toBe('new@test.com');
+  });
+
+  test('falls back to PATCH when the subscriber already exists', async () => {
+    global.fetch
+      .mockResolvedValueOnce(response({ ok: false, status: 422, body: { message: 'already exists' } }))
+      .mockResolvedValueOnce(response());
+
+    await senderService.upsertSubscriber({ email: 'dupe@test.com', first_name: 'D', last_name: 'Upe' });
+
+    const [create, update] = calls();
+    expect(create.method).toBe('POST');
+    expect(update.method).toBe('PATCH');
+    expect(update.url).toBe('https://api.sender.net/v2/subscribers/dupe%40test.com');
+  });
+
+  test('throws with the API message on an unrecoverable error', async () => {
+    global.fetch.mockResolvedValue(response({ ok: false, status: 400, body: { message: 'bad email' } }));
+    await expect(
+      senderService.upsertSubscriber({ email: 'bad', first_name: 'B', last_name: 'D' })
+    ).rejects.toThrow('bad email');
+  });
+
+  test('retries a 429 and then succeeds', async () => {
+    global.fetch
+      .mockResolvedValueOnce(response({ ok: false, status: 429, headers: { 'Retry-After': '0' } }))
+      .mockResolvedValueOnce(response());
+
+    await senderService.upsertSubscriber({ email: 'slow@test.com', first_name: 'S', last_name: 'L' });
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('rate limiting', () => {
+  // X-RateLimit-Reset arrives as a bare integer, so it has to be read numerically —
+  // Date.parse() on it is NaN, which silently degraded the pause to a flat 1s.
+  test('reads X-RateLimit-Reset as epoch seconds and does not pause once it has passed', async () => {
+    const pastEpochSeconds = String(Math.floor(Date.now() / 1000) - 120);
+    global.fetch.mockResolvedValue(response({
+      headers: { 'X-RateLimit-Remaining': '0', 'X-RateLimit-Reset': pastEpochSeconds },
+    }));
+
+    const started = Date.now();
+    await senderService.upsertSubscriber({ email: 'rl@test.com', first_name: 'R', last_name: 'L' });
+
+    expect(Date.now() - started).toBeLessThan(500);
+  });
+});
+
+describe('syncMember', () => {
+  test('adds an active member to the current group and removes them from lapsed', async () => {
+    const member = insertMember(testDb, { email: 'active@test.com', status: 'active' });
+
+    const result = await senderService.syncMember(member.id);
+
+    expect(result.group).toBe(CURRENT_GROUP);
+    const groupCalls = calls().filter(c => c.url.includes('/subscribers/groups/'));
+    expect(groupCalls).toEqual([
+      expect.objectContaining({
+        method: 'POST',
+        url: `https://api.sender.net/v2/subscribers/groups/${CURRENT_GROUP}`,
+        body: { subscribers: ['active@test.com'] },
+      }),
+      expect.objectContaining({
+        method: 'DELETE',
+        url: `https://api.sender.net/v2/subscribers/groups/${LAPSED_GROUP}`,
+        body: { subscribers: ['active@test.com'] },
+      }),
+    ]);
+  });
+
+  test('adds to the target group before removing from the other', async () => {
+    const member = insertMember(testDb, { email: 'active@test.com', status: 'active' });
+
+    await senderService.syncMember(member.id);
+
+    const groupCalls = calls().filter(c => c.url.includes('/subscribers/groups/'));
+    expect(groupCalls[0].method).toBe('POST');
+    expect(groupCalls[0].url).toContain(CURRENT_GROUP);
+  });
+
+  test('a failed group removal does not undo the group the member belongs in', async () => {
+    const member = insertMember(testDb, { email: 'lapsed@test.com', status: 'expired' });
+
+    global.fetch.mockImplementation(async (url, opts) => {
+      if (opts.method === 'DELETE') {
+        return response({ ok: false, status: 422, body: { message: 'not in group' } });
+      }
+      return response();
+    });
+
+    const result = await senderService.syncMember(member.id);
+
+    expect(result.group).toBe(LAPSED_GROUP);
+    const added = calls().find(c => c.method === 'POST' && c.url.includes('/subscribers/groups/'));
+    expect(added.url).toContain(LAPSED_GROUP);
+  });
+
+  test('moves an expired member into the lapsed group', async () => {
+    const member = insertMember(testDb, { email: 'lapsed@test.com', status: 'expired' });
+
+    await senderService.syncMember(member.id);
+
+    const groupCalls = calls().filter(c => c.url.includes('/subscribers/groups/'));
+    expect(groupCalls.find(c => c.url.endsWith(CURRENT_GROUP)).method).toBe('DELETE');
+    expect(groupCalls.find(c => c.url.endsWith(LAPSED_GROUP)).method).toBe('POST');
+  });
+
+  test('removes a cancelled member from both groups', async () => {
+    const member = insertMember(testDb, { email: 'gone@test.com', status: 'cancelled' });
+
+    await senderService.syncMember(member.id);
+
+    const groupCalls = calls().filter(c => c.url.includes('/subscribers/groups/'));
+    expect(groupCalls).toHaveLength(2);
+    expect(groupCalls.every(c => c.method === 'DELETE')).toBe(true);
+  });
+
+  test('skips entirely when Sender is not configured', async () => {
+    delete process.env.SENDER_API_TOKEN;
+    const member = insertMember(testDb, { email: 'nope@test.com', status: 'active' });
+
+    const result = await senderService.syncMember(member.id);
+
+    expect(result.skipped).toBe(true);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('throws when the member has no email', async () => {
+    const member = insertMember(testDb, { email: '', status: 'active' });
+    await expect(senderService.syncMember(member.id)).rejects.toThrow('no email');
+  });
+});
+
+describe('syncMemberSafe', () => {
+  test('swallows API failures so the caller never breaks', async () => {
+    global.fetch.mockResolvedValue(response({ ok: false, status: 400, body: { message: 'nope' } }));
+    const member = insertMember(testDb, { email: 'fail@test.com', status: 'active' });
+
+    await expect(senderService.syncMemberSafe(member.id)).resolves.toBeUndefined();
+  });
+
+  test('does nothing when unconfigured', async () => {
+    delete process.env.SENDER_GROUP_CURRENT;
+    await senderService.syncMemberSafe(1);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('uses the short retry budget so an HTTP handler cannot stall', async () => {
+    // 5xx is retried; the request profile allows one retry, not the background four.
+    global.fetch.mockResolvedValue(response({ ok: false, status: 503 }));
+    const member = insertMember(testDb, { email: 'down@test.com', status: 'active' });
+
+    await senderService.syncMemberSafe(member.id);
+
+    const upserts = calls().filter(c => c.url === 'https://api.sender.net/v2/subscribers');
+    expect(upserts).toHaveLength(2);
+  });
+});
+
+describe('syncMembersSafe', () => {
+  test('syncs a family sharing one email exactly once, as the primary', async () => {
+    const primary = insertMember(testDb, {
+      email: 'family@test.com', status: 'active', first_name: 'Parent',
+    });
+    const kid = insertMember(testDb, {
+      email: 'family@test.com', status: 'active', first_name: 'Kid', primary_member_id: primary.id,
+    });
+
+    await senderService.syncMembersSafe([primary, kid]);
+
+    const upserts = calls().filter(c => c.url === 'https://api.sender.net/v2/subscribers');
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0].body.firstname).toBe('Parent');
+  });
+
+  test('syncs each distinct email', async () => {
+    const a = insertMember(testDb, { email: 'a@test.com', status: 'active' });
+    const b = insertMember(testDb, { email: 'b@test.com', status: 'active' });
+
+    await senderService.syncMembersSafe([a, b]);
+
+    const upserts = calls().filter(c => c.url === 'https://api.sender.net/v2/subscribers');
+    expect(upserts.map(c => c.body.email).sort()).toEqual(['a@test.com', 'b@test.com']);
+  });
+
+  test('does nothing when unconfigured', async () => {
+    delete process.env.SENDER_API_TOKEN;
+    await senderService.syncMembersSafe([{ id: 1, email: 'a@test.com', primary_member_id: null }]);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  // A throw here would 500 the Stripe webhook, and Stripe would re-deliver the event.
+  test('tolerates null entries instead of throwing into the webhook', async () => {
+    const member = insertMember(testDb, { email: 'ok@test.com', status: 'active' });
+
+    await expect(senderService.syncMembersSafe([null, member, undefined])).resolves.toBeUndefined();
+
+    const upserts = calls().filter(c => c.url === 'https://api.sender.net/v2/subscribers');
+    expect(upserts).toHaveLength(1);
+  });
+});
+
+describe('syncEmailSafe', () => {
+  test('drops an address from both groups when no member holds it any more', async () => {
+    await senderService.syncEmailSafe('deleted@test.com');
+
+    const groupCalls = calls().filter(c => c.url.includes('/subscribers/groups/'));
+    expect(groupCalls).toHaveLength(2);
+    expect(groupCalls.every(c => c.method === 'DELETE')).toBe(true);
+    expect(groupCalls.every(c => c.body.subscribers[0] === 'deleted@test.com')).toBe(true);
+  });
+
+  test('re-syncs the surviving member when one still holds the address', async () => {
+    insertMember(testDb, { email: 'family@test.com', status: 'active', first_name: 'Parent' });
+
+    await senderService.syncEmailSafe('family@test.com');
+
+    const upserts = calls().filter(c => c.url === 'https://api.sender.net/v2/subscribers');
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0].body.firstname).toBe('Parent');
+    const added = calls().find(c => c.method === 'POST' && c.url.includes('/subscribers/groups/'));
+    expect(added.url).toContain(CURRENT_GROUP);
+  });
+
+  test('does nothing for a blank address or when unconfigured', async () => {
+    await senderService.syncEmailSafe('');
+    expect(global.fetch).not.toHaveBeenCalled();
+
+    delete process.env.SENDER_GROUP_LAPSED;
+    await senderService.syncEmailSafe('x@test.com');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('syncAllMembers', () => {
+  test('upserts each member then reconciles groups in bulk', async () => {
+    insertMember(testDb, { email: 'a@test.com', status: 'active' });
+    insertMember(testDb, { email: 'b@test.com', status: 'expired' });
+    insertMember(testDb, { email: 'c@test.com', status: 'pending' });
+
+    const stats = await senderService.syncAllMembers();
+
+    expect(stats.total).toBe(3);
+    expect(stats.synced).toBe(3);
+    expect(stats.failed).toBe(0);
+    expect(stats.groups).toEqual({ current: 1, lapsed: 1, removed: 1 });
+
+    const upserts = calls().filter(c => c.url === 'https://api.sender.net/v2/subscribers');
+    expect(upserts).toHaveLength(3);
+
+    const addCurrent = calls().find(
+      c => c.method === 'POST' && c.url.endsWith(`/groups/${CURRENT_GROUP}`)
+    );
+    expect(addCurrent.body.subscribers).toEqual(['a@test.com']);
+
+    const removeCurrent = calls().find(
+      c => c.method === 'DELETE' && c.url.endsWith(`/groups/${CURRENT_GROUP}`)
+    );
+    expect(removeCurrent.body.subscribers).toEqual(expect.arrayContaining(['b@test.com', 'c@test.com']));
+  });
+
+  test('one failing member does not abort the batch', async () => {
+    insertMember(testDb, { email: 'ok1@test.com', status: 'active' });
+    insertMember(testDb, { email: 'boom@test.com', status: 'active' });
+    insertMember(testDb, { email: 'ok2@test.com', status: 'active' });
+
+    global.fetch.mockImplementation(async (url, opts) => {
+      const body = opts.body ? JSON.parse(opts.body) : {};
+      if (body.email === 'boom@test.com') {
+        return response({ ok: false, status: 400, body: { message: 'rejected' } });
+      }
+      return response();
+    });
+
+    const stats = await senderService.syncAllMembers();
+
+    expect(stats.synced).toBe(2);
+    expect(stats.failed).toBe(1);
+  });
+
+  test('a rejected group removal does not abandon the rest of the reconciliation', async () => {
+    insertMember(testDb, { email: 'a@test.com', status: 'active' });
+    insertMember(testDb, { email: 'b@test.com', status: 'expired' });
+
+    global.fetch.mockImplementation(async (url, opts) => {
+      if (opts.method === 'DELETE') {
+        return response({ ok: false, status: 422, body: { message: 'not in group' } });
+      }
+      return response();
+    });
+
+    const stats = await senderService.syncAllMembers();
+
+    expect(stats.groups).toEqual({ current: 1, lapsed: 1, removed: 0 });
+    const adds = calls().filter(c => c.method === 'POST' && c.url.includes('/subscribers/groups/'));
+    expect(adds.map(c => c.url.split('/').pop()).sort()).toEqual([CURRENT_GROUP, LAPSED_GROUP].sort());
+  });
+
+  test('members whose upsert failed are left out of the group batches', async () => {
+    insertMember(testDb, { email: 'ok@test.com', status: 'active' });
+    insertMember(testDb, { email: 'boom@test.com', status: 'active' });
+
+    global.fetch.mockImplementation(async (url, opts) => {
+      const body = opts.body ? JSON.parse(opts.body) : {};
+      if (body.email === 'boom@test.com') {
+        return response({ ok: false, status: 400, body: { message: 'rejected' } });
+      }
+      return response();
+    });
+
+    const stats = await senderService.syncAllMembers();
+
+    expect(stats.failed).toBe(1);
+    expect(stats.groups.current).toBe(1);
+    const addCurrent = calls().find(
+      c => c.method === 'POST' && c.url.endsWith(`/groups/${CURRENT_GROUP}`)
+    );
+    expect(addCurrent.body.subscribers).toEqual(['ok@test.com']);
+  });
+
+  test('dedupes a family sharing the primary email into one subscriber', async () => {
+    const primary = insertMember(testDb, { email: 'family@test.com', status: 'active', first_name: 'Parent' });
+    insertMember(testDb, {
+      email: 'family@test.com',
+      status: 'active',
+      first_name: 'Kid',
+      primary_member_id: primary.id,
+    });
+
+    const stats = await senderService.syncAllMembers();
+
+    expect(stats.total).toBe(1);
+    const upserts = calls().filter(c => c.url === 'https://api.sender.net/v2/subscribers');
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0].body.firstname).toBe('Parent');
+  });
+
+  test('dry run makes no API calls but still reports the plan', async () => {
+    insertMember(testDb, { email: 'a@test.com', status: 'active' });
+    insertMember(testDb, { email: 'b@test.com', status: 'expired' });
+
+    const stats = await senderService.syncAllMembers({ dryRun: true });
+
+    expect(stats.groups).toEqual({ current: 1, lapsed: 1, removed: 0 });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  test('throws when Sender is not configured', async () => {
+    delete process.env.SENDER_API_TOKEN;
+    await expect(senderService.syncAllMembers()).rejects.toThrow('not configured');
+  });
+});

--- a/user_guide/06-email-system.md
+++ b/user_guide/06-email-system.md
@@ -42,6 +42,35 @@ The email log is accessible from the **Emails** section. It shows a complete his
 
 Use the log to verify that automated emails were delivered or to diagnose delivery issues.
 
+## Newsletter Lists in Sender.net
+
+Club newsletters and campaigns are sent from Sender.net, not from the blast tool. The member list is copied there automatically so you never have to maintain it by hand.
+
+Members land in one of two groups:
+
+| Group | Who is in it |
+|-------|--------------|
+| **Current** | Members in good standing, including lifetime members |
+| **Lapsed** | Members whose membership has expired |
+
+People who started a signup but never paid, and members marked cancelled, are in neither group. They stay in your Sender account as subscribers but receive nothing sent to a group. Because of that, sending to all subscribers rather than to a group reaches people who never joined and people who cancelled — send to **Current** (and **Lapsed**, if you mean to reach them) instead.
+
+A member's group is updated when their payment goes through, when they renew, when you add them in admin, when you record a payment against their account, when you delete them, and whenever you save a change to their record.
+
+Membership expiry is judged by the expiry date on the record, not by anything an administrator has to set — so a member whose date has passed counts as Lapsed. Nothing fires on the day a membership expires, though: they move to the Lapsed group the next time their record is touched or the full refresh below runs. Run the refresh on a regular schedule (monthly, or after each renewal season) or the Lapsed group will lag behind reality.
+
+Family memberships appear in Sender as a single subscriber under the primary member's name, because everyone on a family membership shares one email address.
+
+### When a member changes their email
+
+Changing an email address in admin adds the new address to Sender. The old address stays as a separate subscriber, because Sender does not allow an existing subscriber to be renamed. If someone tells you they still get club email at an old address, they can unsubscribe from it using the link in the footer.
+
+### Refreshing the whole list
+
+An administrator with server access can re-copy every member into Sender by running `node scripts/sync-sender.js`. Adding `--dry-run` reports what would change without sending anything. The sync only ever adds and regroups; it never deletes subscribers, so running it again is safe.
+
+Nothing runs this on a schedule yet, so it is a manual step. It is also the repair mechanism when Sender is briefly unreachable during a signup — the club site never fails a payment over a newsletter sync, it just logs the miss and carries on.
+
 ## Troubleshooting Delivery
 
 If emails show as **failed** in the log:


### PR DESCRIPTION
## Summary

Club newsletters go out from Sender.net, so its subscriber list had to be maintained by hand and drifted from the member roster. This copies members over automatically and keeps two groups in sync: Current for members in good standing plus lifetime members, Lapsed for those whose membership has run out. Pending and cancelled members belong to neither.

The whole integration is gated on SENDER_API_TOKEN, SENDER_GROUP_CURRENT and SENDER_GROUP_LAPSED — with any of them unset every entry point returns without a network call, so nothing changes for a deployment that does not use Sender.

- Lapsed is derived from expiry_date, not read off status: nothing in the app ever writes status='expired', so a membership that simply runs out keeps status='active' with a past date. Mirrors the expired predicate the member list already uses
- Family memberships appear as one subscriber under the primary. Sub-members share the primary's email and Sender keys on email, so dedupeByEmail collapses them or a sub-member's name would overwrite the primary's
- Subscriber writes never send `groups`, which on Sender replaces group assignment and would wipe anything curated by hand. Groups are reconciled separately, adds before removes, and a failed remove is logged rather than thrown since removing from a group the subscriber was never in is the normal case
- Two retry budgets. The CLI waits out a rate-limit window; request handlers get a short one, because a Stripe webhook that blocks for minutes gets re-delivered and the signup is processed twice. Reads X-RateLimit-Reset numerically — Sender sends a bare integer, so Date.parse on it is always NaN
- Sync hooks on the Stripe webhook (last, and non-throwing — a Sender outage must never fail a paid signup) and on admin member create, update, delete, recorded payment, family upgrade, and family-member removal. Delete reconciles the address rather than the member id: syncAllMembers only sees members who still exist, so without it a deleted member would keep receiving newsletters forever
- scripts/sync-sender.js backfills everything, with --dry-run. It only adds and regroups, never deletes subscribers, so it is safe to re-run. Nothing schedules it yet, which means it is both the repair path for a missed sync and the only thing that moves a newly expired member into Lapsed

Tests: 47 unit tests over grouping, dedupe, the upsert fallback, retry and rate-limit handling, and the full backfill. Documents the admin-facing behaviour in the email-system user guide, including the old address left behind on an email change.

## Checklist
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] No `.env` or secrets committed
