### PR TITLE
Rework the admin UI and give it a design system

### DIFF
--- a/middleware/locals.js
+++ b/middleware/locals.js
@@ -16,10 +16,14 @@ async function injectLocals(req, res, next) {
     // in a copyable field. One-shot like the other flashes — it is a freshly minted credential,
     // so it should not linger on the page after the admin navigates away.
     res.locals.flash_renewal_link = (req.session && req.session.flash_renewal_link) || null;
+    // Names the disclosure that raised a validation error, so the member record can
+    // re-open it rather than showing a red banner above a collapsed control.
+    res.locals.flash_reopen = (req.session && req.session.flash_reopen) || null;
     if (req.session) {
       delete req.session.flash_success;
       delete req.session.flash_error;
       delete req.session.flash_renewal_link;
+      delete req.session.flash_reopen;
     }
 
     // hCaptcha site key (empty string when not configured — widget is hidden)
@@ -38,6 +42,27 @@ async function injectLocals(req, res, next) {
           return date.split('T')[0].split(' ')[0];
       }
       return '';
+    };
+
+    // Money formatting. Amounts are integer cents in the DB.
+    //
+    // sumCompletedCents() returns null on an empty payments table, so coerce before
+    // dividing — `(null / 100).toFixed(2)` only yields "0.00" by coercion luck.
+    res.locals.formatMoney = function(cents) {
+      return ((Number(cents) || 0) / 100)
+        .toLocaleString('en-US', {style: 'currency', currency: 'USD'});
+    };
+
+    // Short form for KPI tiles, which have a card's width to work with rather than a
+    // table cell's: thousands separators, and no ".00" on whole amounts. "$2,034" is
+    // three glyphs narrower than "$2034.00" and reads faster at 36px.
+    res.locals.formatMoneyShort = function(cents) {
+      const value = (Number(cents) || 0) / 100;
+      return value.toLocaleString('en-US', {
+        style: 'currency',
+        currency: 'USD',
+        minimumFractionDigits: Number.isInteger(value) ? 0 : 2,
+      });
     };
 
     next();

--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -1,9 +1,9 @@
 /* === Admin Layout === */
 .admin-body {
   margin: 0;
-  background: #f0f2f5;
+  background: var(--page-bg);
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  color: #333;
+  color: var(--text);
   line-height: 1.6;
 }
 
@@ -15,8 +15,8 @@
 /* === Sidebar === */
 .admin-sidebar {
   width: 240px;
-  background: #002a5c;
-  color: #fff;
+  background: var(--navy);
+  color: var(--surface);
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
@@ -31,7 +31,7 @@
 }
 
 .sidebar-brand a {
-  color: #fff;
+  color: var(--surface);
   text-decoration: none;
   display: flex;
   align-items: center;
@@ -53,20 +53,20 @@
   padding: 0.75rem 1.25rem;
   font-size: 0.95rem;
   transition: all 0.15s ease;
-  min-height: 44px;
+  min-height: var(--tap-target);
   display: flex;
   align-items: center;
 }
 
 .sidebar-nav a:hover {
   background: rgba(255,255,255,0.1);
-  color: #fff;
+  color: var(--surface);
   text-decoration: none;
 }
 
 .sidebar-nav a.active {
   background: rgba(105,190,40,0.2);
-  color: #69be28;
+  color: var(--green);
   font-weight: 600;
 }
 
@@ -85,13 +85,13 @@
   cursor: pointer;
   text-align: left;
   width: 100%;
-  min-height: 44px;
+  min-height: var(--tap-target);
   transition: all 0.15s ease;
 }
 
 .sidebar-logout:hover {
   background: rgba(255,255,255,0.1);
-  color: #fff;
+  color: var(--surface);
 }
 
 /* === Main Area === */
@@ -103,9 +103,9 @@
 }
 
 .admin-topbar {
-  background: #fff;
+  background: var(--surface);
   padding: 1.25rem 2rem;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--border);
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -113,7 +113,7 @@
 
 .admin-page-title {
   font-size: 1.5rem;
-  color: #002a5c;
+  color: var(--navy);
   margin: 0;
   font-weight: 600;
 }
@@ -125,7 +125,7 @@
   font-size: 1.2rem;
   cursor: pointer;
   padding: 0.25rem 0.5rem;
-  border-radius: 4px;
+  border-radius: var(--radius-control);
 }
 
 .admin-content {
@@ -147,44 +147,64 @@
 }
 
 /* === Stats Grid === */
+/* robot/resources/admin.resource waits for .stats-grid to become visible as its
+   "login finished" signal, and admin_auth.robot counts exactly 7 .stat-card elements. */
 .stats-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  /* 160px floor rather than 180px, which combined with the tighter card padding leaves
+     real room for the value. The overflow fix proper is on .stat-number below — a bigger
+     floor alone only moves the width at which a long figure spills again. */
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 1rem;
   margin-bottom: 1.5rem;
 }
 
 .stat-card {
-  background: #fff;
-  border-radius: 8px;
-  padding: 1.75rem;
+  background: var(--surface);
+  border-radius: var(--radius-card);
+  /* Was 1.75rem all round, which left only ~124px of content inside a 180px track. */
+  padding: 1.5rem 1rem;
   text-align: center;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+  box-shadow: var(--shadow-card);
+  min-width: 0;                 /* grid items floor at min-content without this */
+  container-type: inline-size;  /* lets .stat-number size off the card, not the viewport */
+  display: flex;
+  flex-direction: column;
 }
 
 a.stat-card {
-  display: block;
   text-decoration: none;
   transition: box-shadow 0.15s ease, transform 0.15s ease;
 }
 
 a.stat-card:hover {
-  box-shadow: 0 3px 8px rgba(0,0,0,0.14);
+  box-shadow: var(--shadow-card-hover);
   transform: translateY(-1px);
 }
 
 .stat-number {
-  font-size: 2.25rem;
+  /* 2.25rem is the design size, and 24cqi reaches it at ~150px of content width, so a
+     roomy card looks exactly as it did. A narrow card — or a long value like $1,234,567 —
+     scales the type down instead of painting outside the card, which is what a fixed
+     2.25rem "$2034.00" used to do in a 180px track with 1.75rem of padding. */
+  font-size: clamp(1.25rem, 24cqi, 2.25rem);
   font-weight: 700;
-  color: #002a5c;
+  color: var(--navy);
   line-height: 1.2;
+  font-variant-numeric: tabular-nums;
+  overflow-wrap: anywhere;      /* seatbelt: nothing escapes the card */
 }
 
 .stat-label {
-  color: #666;
+  color: var(--text-muted);
   font-size: 0.875rem;
-  margin-top: 0.5rem;
+  line-height: 1.25;
   font-weight: 500;
+  margin-top: auto;             /* labels sit on the card floor... */
+  padding-top: 0.5rem;
+  min-height: 2.5em;            /* ...and every card reserves two lines, so the two-line
+                                   "Enrolled 2026-2027 Season" stops making its
+                                   one-line siblings look misaligned */
 }
 
 /* === Admin Grid === */
@@ -196,15 +216,15 @@ a.stat-card:hover {
 }
 
 .admin-panel {
-  background: #fff;
-  border-radius: 8px;
+  background: var(--surface);
+  border-radius: var(--radius-card);
   padding: 1.75rem;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+  box-shadow: var(--shadow-card);
   margin-bottom: 1.5rem;
 }
 
 .admin-panel h3 {
-  color: #002a5c;
+  color: var(--navy);
   margin-bottom: 1.25rem;
   font-size: 1.1rem;
   font-weight: 600;
@@ -219,16 +239,16 @@ a.stat-card:hover {
 
 .admin-table th {
   background: #f8f8f8;
-  color: #002a5c;
+  color: var(--navy);
   padding: 0.875rem 1rem;
   text-align: left;
   font-weight: 600;
-  border-bottom: 2px solid #e0e0e0;
+  border-bottom: 2px solid var(--border);
 }
 
 .admin-table td {
   padding: 0.875rem 1rem;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--rule);
   vertical-align: middle;
 }
 
@@ -241,7 +261,7 @@ a.stat-card:hover {
 }
 
 .admin-table a:hover {
-  color: #69be28;
+  color: var(--green);
 }
 
 .detail-table {
@@ -252,7 +272,7 @@ a.stat-card:hover {
 .detail-table th {
   text-align: left;
   padding: 0.75rem 1rem 0.75rem 0;
-  color: #666;
+  color: var(--text-muted);
   font-weight: 600;
   width: 160px;
   vertical-align: top;
@@ -335,15 +355,15 @@ a.stat-card:hover {
 .search-form input {
   padding: 0.625rem 0.875rem;
   border: 1px solid #ccc;
-  border-radius: 4px;
+  border-radius: var(--radius-control);
   font-size: 0.9rem;
   line-height: 1.5;
-  min-height: 40px;
+  min-height: var(--tap-target-md);
 }
 
 .search-form input:focus {
   outline: none;
-  border-color: #002a5c;
+  border-color: var(--navy);
   box-shadow: 0 0 0 3px rgba(0,42,92,0.1);
 }
 
@@ -361,10 +381,10 @@ a.stat-card:hover {
 .search-form-wide select {
   padding: 0.625rem 0.875rem;
   border: 1px solid #ccc;
-  border-radius: 4px;
+  border-radius: var(--radius-control);
   font-size: 0.9rem;
-  min-height: 40px;
-  background: #fff;
+  min-height: var(--tap-target-md);
+  background: var(--surface);
 }
 
 .toolbar-actions {
@@ -388,35 +408,35 @@ a.stat-card:hover {
   padding: 0.4rem 0.9rem;
   border: 1px solid #ccc;
   border-radius: 999px;
-  background: #fff;
-  color: #333;
+  background: var(--surface);
+  color: var(--text);
   font-size: 0.875rem;
   font-weight: 500;
   text-decoration: none;
 }
 
 .view-pill:hover {
-  border-color: #002a5c;
-  color: #002a5c;
+  border-color: var(--navy);
+  color: var(--navy);
 }
 
 .view-pill-active,
 .view-pill-active:hover {
-  background: #002a5c;
-  border-color: #002a5c;
-  color: #fff;
+  background: var(--navy);
+  border-color: var(--navy);
+  color: var(--surface);
 }
 
 .pill-count {
   font-size: 0.75rem;
-  color: #666;
+  color: var(--text-muted);
   background: #f0f0f0;
   border-radius: 999px;
   padding: 0.05rem 0.5rem;
 }
 
 .view-pill-active .pill-count {
-  color: #fff;
+  color: var(--surface);
   background: rgba(255,255,255,0.2);
 }
 
@@ -428,7 +448,7 @@ a.stat-card:hover {
 }
 
 .admin-table th .sort-link:hover {
-  color: #69be28;
+  color: var(--green);
 }
 
 .sort-indicator {
@@ -450,7 +470,7 @@ a.stat-card:hover {
   display: block;
   margin-bottom: 0.5rem;
   font-weight: 600;
-  color: #333;
+  color: var(--text);
   font-size: 0.9rem;
 }
 
@@ -466,11 +486,11 @@ a.stat-card:hover {
   width: 100%;
   padding: 0.75rem 0.875rem;
   border: 1px solid #ccc;
-  border-radius: 4px;
+  border-radius: var(--radius-control);
   font-size: 0.9rem;
   font-family: inherit;
   line-height: 1.5;
-  min-height: 44px;
+  min-height: var(--tap-target);
 }
 
 .admin-content .form-group textarea {
@@ -492,9 +512,13 @@ a.stat-card:hover {
   margin: 0;
 }
 
+/* `small` is inline, so once the field above it was capped at --measure-form the hint
+   flowed into the space beside the input instead of under it — and margin-top did
+   nothing on an inline box either. */
 .admin-content .form-group .form-hint {
+  display: block;
   font-size: 0.8rem;
-  color: #6c757d;
+  color: var(--text-subtle);
   margin-top: 0.25rem;
 }
 
@@ -502,7 +526,7 @@ a.stat-card:hover {
 .admin-content .form-group select:focus,
 .admin-content .form-group textarea:focus {
   outline: none;
-  border-color: #002a5c;
+  border-color: var(--navy);
   box-shadow: 0 0 0 3px rgba(0,42,92,0.1);
 }
 
@@ -547,65 +571,65 @@ a.stat-card:hover {
    in this file kept a white label on a darker green — 3:1, the contrast failure the
    navy label exists to fix — so admin buttons regressed on hover only. */
 
-/* Needs its own color now that the duplicated .btn no longer sets #fff here: it would
+/* Needs its own color now that the duplicated .btn no longer sets var(--surface) here: it would
    otherwise inherit the navy label from style.css and render navy on navy. Currently
    unused in views/, kept because the class reads as an obvious thing to reach for. */
 .btn-primary {
-  background: #002a5c;
-  color: #fff;
+  background: var(--navy);
+  color: var(--surface);
 }
 
 .btn-primary:hover {
-  background: #001d42;
-  color: #fff;
+  background: var(--navy-dark);
+  color: var(--surface);
 }
 
 .btn-sm {
   display: inline-block;
   padding: 0.5rem 0.875rem;
   font-size: 0.875rem;
-  border-radius: 4px;
-  background: #002a5c;
-  color: #fff;
+  border-radius: var(--radius-control);
+  background: var(--navy);
+  color: var(--surface);
   border: none;
   cursor: pointer;
   text-decoration: none;
   line-height: 1.5;
-  min-height: 36px;
+  min-height: var(--tap-target-sm);
   font-weight: 600;
   margin: 0.2rem;
 }
 
 .btn-sm:hover {
-  background: #001d42;
+  background: var(--navy-dark);
   text-decoration: none;
-  color: #fff;
+  color: var(--surface);
 }
 
 .btn-danger {
-  background: #dc3545;
-  color: #fff;
+  background: var(--danger);
+  color: var(--surface);
   border: none;
   padding: 0.75rem 1.75rem;
-  border-radius: 4px;
+  border-radius: var(--radius-control);
   cursor: pointer;
   font-size: 1rem;
   font-weight: 600;
   line-height: 1.5;
-  min-height: 44px;
+  min-height: var(--tap-target);
   text-decoration: none;
 }
 
 .btn-danger:hover {
-  background: #c82333;
+  background: var(--danger-dark);
   text-decoration: none;
-  color: #fff;
+  color: var(--surface);
 }
 
 .btn-sm.btn-danger {
   padding: 0.5rem 0.875rem;
   font-size: 0.875rem;
-  min-height: 36px;
+  min-height: var(--tap-target-sm);
 }
 
 /* A submit button that has to sit inline beside real links — used for actions that
@@ -617,7 +641,7 @@ a.stat-card:hover {
   padding: 0;
   margin: 0;
   font: inherit;
-  color: #002a5c;
+  color: var(--navy);
   text-decoration: none;
   cursor: pointer;
 }
@@ -637,10 +661,10 @@ a.stat-card:hover {
 }
 
 .pagination a {
-  color: #002a5c;
+  color: var(--navy);
   text-decoration: none;
   padding: 0.5rem 0.75rem;
-  min-height: 40px;
+  min-height: var(--tap-target-md);
   display: inline-flex;
   align-items: center;
   font-weight: 500;
@@ -648,7 +672,7 @@ a.stat-card:hover {
 
 .pagination a:hover {
   text-decoration: underline;
-  color: #69be28;
+  color: var(--green);
 }
 
 /* === Gallery Admin === */
@@ -659,11 +683,18 @@ a.stat-card:hover {
 }
 
 .gallery-admin-card {
-  background: #fff;
-  border-radius: 8px;
+  background: var(--surface);
+  border-radius: var(--radius-card);
   overflow: hidden;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
+  box-shadow: var(--shadow-card);
   padding: 0.75rem;
+}
+
+.gallery-admin-thumb {
+  width: 100%;
+  height: 150px;
+  object-fit: cover;
+  border-radius: var(--radius-control);
 }
 
 .gallery-admin-info {
@@ -679,12 +710,38 @@ a.stat-card:hover {
 
 /* === Card Row === */
 .card-row {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
   padding: 0.5rem 0;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--rule);
   font-size: 0.9rem;
+}
+
+.card-row:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.card-row-year {
+  color: var(--text-muted);
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+/* All three actions on one line at a matching height. .btn-sm's 0.2rem margin fought the
+   gap and, in the narrow rail, a wrapped label made one button taller than its siblings —
+   so labels stay on one line and the buttons share an explicit height. */
+.card-row-actions {
+  display: flex;
+  align-items: stretch;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.card-row-actions .btn-sm {
+  margin: 0;
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* === Login === */
@@ -693,14 +750,14 @@ a.stat-card:hover {
   justify-content: center;
   align-items: center;
   min-height: 100vh;
-  background: #002a5c;
+  background: var(--navy);
   margin: 0;
 }
 
 .admin-login-card {
-  background: #fff;
+  background: var(--surface);
   padding: 2.5rem;
-  border-radius: 8px;
+  border-radius: var(--radius-card);
   width: 100%;
   max-width: 380px;
   text-align: center;
@@ -708,13 +765,13 @@ a.stat-card:hover {
 }
 
 .admin-login-card h2 {
-  color: #002a5c;
+  color: var(--navy);
   margin-bottom: 1.5rem;
 }
 
 /* === Utility === */
 .text-muted {
-  color: #999;
+  color: var(--text-faint);
   font-size: 0.9rem;
 }
 
@@ -723,7 +780,7 @@ a.stat-card:hover {
   background: #d1ecf1;
   color: #0c5460;
   border: 1px solid #bee5eb;
-  border-radius: 4px;
+  border-radius: var(--radius-control);
   padding: 0.6rem 1rem;
   margin-bottom: 1rem;
   font-size: 0.9rem;
@@ -746,7 +803,7 @@ a.stat-card:hover {
 
 .draft-discard-btn:hover {
   background: #0c5460;
-  color: #fff;
+  color: var(--surface);
 }
 
 /* === Responsive === */
@@ -792,6 +849,10 @@ a.stat-card:hover {
     grid-template-columns: 1fr 1fr;
   }
 
+  .stat-card {
+    padding: 1.25rem 0.875rem;
+  }
+
   .admin-toolbar {
     flex-direction: column;
     align-items: stretch;
@@ -835,4 +896,614 @@ a.stat-card:hover {
   .form-actions .btn-danger {
     width: 100%;
   }
+}
+
+/* === Shared components ===
+   These back the mixins in views/admin/mixins.pug. Several of the classes below were
+   already in use by templates that carried the layout inline because no rule existed —
+   .admin-actions was referenced by three pages and defined nowhere. */
+
+/* .admin-actions was the second, undefined spelling of .admin-toolbar. Aliased rather
+   than deleted so a stray usage still lands somewhere sane. */
+.admin-actions {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+/* Wraps a single-button POST so it sits inline next to a sibling link. Was
+   style="display:inline" on seven forms; inline-flex keeps the button in the parent's
+   flex line instead of dropping out of it. */
+.inline-form {
+  display: inline-flex;
+  margin: 0;
+}
+
+.row-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.image-preview img {
+  max-height: 120px;
+  margin-top: 0.5rem;
+  border-radius: var(--radius-control);
+}
+
+.image-preview--round img {
+  border-radius: 50%;
+}
+
+.avatar-sm {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.sidebar-logo {
+  height: 40px;
+}
+
+.login-logo {
+  height: 60px;
+  margin-bottom: 1rem;
+}
+
+.radio-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  margin-bottom: 1rem;
+}
+
+/* admins.pug's own spelling of .form-grid. */
+.form-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.qr-block {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.qr-image {
+  border: 1px solid #ddd;
+  background: var(--surface);
+}
+
+.empty-state {
+  color: var(--text-muted);
+  padding: 1.5rem 0;
+}
+
+.table-responsive {
+  overflow-x: auto;
+}
+
+.btn-block {
+  width: 100%;
+}
+
+/* One-time code: wide tracking makes six digits scannable as a group. */
+.input-otp {
+  text-align: center;
+  font-size: 1.5rem;
+  letter-spacing: 0.5rem;
+}
+
+.input-mono {
+  font-family: monospace;
+}
+
+/* Key/value variant of .admin-table: a label column and a value column, no thead. */
+.admin-table--kv th {
+  width: 14rem;
+  background: none;
+  border-bottom: 1px solid var(--rule);
+}
+
+/* Section headings inside admin content. Replaced eight identical inline
+   style="margin-top: 1.5rem" attributes. */
+.admin-content h2,
+.admin-content h3 {
+  margin-top: 1.5rem;
+}
+
+.admin-content h2:first-child,
+.admin-content h3:first-child,
+.admin-panel h3 {
+  margin-top: 0;
+}
+
+.page-footnote {
+  margin-top: 1.5rem;
+}
+
+/* Readable measures. Deliberately scoped to opt-in classes rather than set on
+   .admin-content: the members and payments tables want the full width, and capping
+   them all would trade one layout complaint for another. */
+.admin-content .form-group--narrow input,
+.admin-content .form-group--narrow select {
+  max-width: var(--measure-form);
+}
+
+.form-grid--narrow {
+  max-width: 54rem;
+}
+
+/* === Audit Log ===
+   Moved out of a `style.` block inside views/admin/audit.pug, which also leaked a bare
+   `details summary` rule to every page that template rendered — it would now fight the
+   disclosure component below. Values carried over as they were, with the colour
+   literals mapped onto the tokens where they matched. */
+.audit-filters {
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.audit-filters select {
+  padding: 0.3rem 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: var(--radius-control);
+}
+
+.audit-meta {
+  color: var(--text-muted);
+  font-size: 0.875rem;
+  margin-bottom: 0.5rem;
+}
+
+.audit-ts {
+  white-space: nowrap;
+  font-size: 0.8rem;
+  color: #555;
+}
+
+.audit-json {
+  max-height: 300px;
+  overflow: auto;
+  background: #f8f8f8;
+  border: 1px solid #ddd;
+  border-radius: var(--radius-control);
+  padding: 0.5rem;
+  font-size: 0.75rem;
+  white-space: pre-wrap;
+}
+
+.audit-diff {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+  margin-top: 0.4rem;
+}
+
+.audit-diff th,
+.audit-diff td {
+  padding: 0.2rem 0.5rem;
+  border: 1px solid #e5e7eb;
+}
+
+.audit-diff th {
+  background: #f3f4f6;
+  font-weight: 600;
+}
+
+.audit-old {
+  color: #991b1b;
+  background: #fff5f5;
+  word-break: break-all;
+}
+
+.audit-new {
+  color: #065f46;
+  background: #f0fff4;
+  word-break: break-all;
+}
+
+/* The audit table's JSON/diff toggles are plain <details>, not the disclosure
+   component, so they keep a quiet text-link affordance. */
+.audit-diff-toggle > summary,
+.admin-table details > summary {
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: #4b5563;
+}
+
+/* INSERT/UPDATE/DELETE pills. The template asked for .audit-badge--insert and friends,
+   which were defined in neither stylesheet nor in the template's own style block, so
+   every audit action rendered as bare unstyled text. Folded into the .badge-* scale. */
+.badge-audit-insert {
+  background: #d4edda;
+  color: #155724;
+  border: 1px solid #c3e6cb;
+}
+
+.badge-audit-update {
+  background: #fff3cd;
+  color: #856404;
+  border: 1px solid #ffeaa7;
+}
+
+.badge-audit-delete {
+  background: #f8d7da;
+  color: #721c24;
+  border: 1px solid #f5c6cb;
+}
+
+/* Tight variant for an action row that sits directly under its input. */
+.form-actions--tight {
+  margin-top: 0.5rem;
+}
+
+.mt-sm {
+  margin-top: 0.5rem;
+}
+
+.member-family-section {
+  margin-top: 2rem;
+}
+
+.mt-md {
+  margin-top: 1rem;
+}
+
+.mb-lg {
+  margin-bottom: 2rem;
+}
+
+.rule-lg {
+  margin: 2rem 0;
+}
+
+/* === Member Record Page ===
+   One record with a sane column system, rather than a stack of equal panels. The
+   previous layout reused .admin-grid (auto-fit, minmax(400px, 1fr)), which on a wide
+   screen handed the two-line Membership Cards panel half the viewport. */
+.record-layout {
+  display: grid;
+  /* minmax(0, 1fr), not 1fr: the 5-column payment tables would otherwise force the
+     column wider than its share and blow out the grid. No max-width — the record uses
+     the full content width, and the rail stays a fixed 320px so the extra room goes to
+     the tables that want it. */
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.record-main > .admin-panel:last-child,
+.record-rail > .admin-panel:last-child {
+  margin-bottom: 0;
+}
+
+.snapshot-table {
+  width: 100%;
+  font-size: 0.9rem;
+}
+
+.snapshot-table th {
+  text-align: left;
+  padding: 0.4rem 0.75rem 0.4rem 0;
+  color: var(--text-muted);
+  font-weight: 600;
+  white-space: nowrap;
+  vertical-align: baseline;
+}
+
+.snapshot-table td {
+  padding: 0.4rem 0;
+  vertical-align: baseline;
+}
+
+.family-member-list {
+  margin: 0 0 0.5rem;
+  padding-left: 1.5rem;
+}
+
+.family-member-list li {
+  margin-bottom: 0.25rem;
+}
+
+/* The rail is dropped before the 768px mobile breakpoint: below this the main column is
+   already too tight for the payment tables to sit beside a 320px rail. */
+@media (max-width: 1080px) {
+  .record-layout {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+/* === Action bar === */
+.record-actionbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  background: var(--surface);
+  border-radius: var(--radius-card);
+  padding: 1rem 1.25rem;
+  box-shadow: var(--shadow-card);
+  margin-bottom: 1.5rem;
+}
+
+.actionbar-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+/* Each action is its own POST form. They used to carry style="display:inline", which
+   left them outside the flex layout — the actual cause of the two ragged button rows. */
+.record-actionbar form {
+  display: inline-flex;
+  margin: 0;
+}
+
+.actionbar-sep {
+  width: 1px;
+  align-self: stretch;
+  background: #e5e5e5;
+}
+
+.actionbar-danger {
+  margin-left: auto;
+}
+
+/* .btn is 0.75rem/1.75rem padding; .btn-outline is 0.625rem plus a 2px border. Side by
+   side they read as two different sizes even though both clear 44px. One toolbar size. */
+.btn-compact {
+  padding: 0.5rem 1.1rem;
+  font-size: 0.9rem;
+  min-height: var(--tap-target-md);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* min-height is only a floor: .btn-outline's 2px border pushed its content box to 42px
+   while the borderless .btn and .btn-danger settled at 40px, so the row sat a pixel out
+   of alignment. Take the border back out of the block padding. A robot test measures the
+   button tops, so this stays honest. */
+.btn-outline.btn-compact {
+  padding-block: calc(0.5rem - 2px);
+}
+
+/* Inline "Remove" beside a family member's name. */
+.btn-tiny {
+  padding: 1px 8px;
+  font-size: 0.75rem;
+  min-height: 0;
+  line-height: 1.5;
+  border-radius: var(--radius-control);
+}
+
+@media (max-width: 768px) {
+  .record-actionbar,
+  .actionbar-group {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  /* The shared 768px rule widens .btn and .btn-danger but not .btn-outline. */
+  .record-actionbar form,
+  .record-actionbar .btn-compact {
+    width: 100%;
+  }
+
+  .actionbar-sep {
+    display: none;
+  }
+
+  .actionbar-danger {
+    margin-left: 0;
+    margin-top: 0.25rem;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--rule);
+  }
+}
+
+/* === Disclosure ===
+   Button-driven reveal for the forms that used to sit permanently expanded beneath the
+   record. Native <details>: no JS, so helmet's script-src-attr 'none' cannot break it,
+   it works before admin.js parses, and Enter/Space plus the expanded-state announcement
+   come for free. */
+.disclosure {
+  margin-top: 1.5rem;
+  border-top: 1px solid var(--rule);
+  padding-top: 1.25rem;
+}
+
+.disclosure > summary {
+  display: inline-flex;          /* also suppresses the Chromium marker */
+  align-items: center;
+  gap: 0.5rem;
+  width: max-content;
+  list-style: none;              /* Firefox */
+  cursor: pointer;
+  border: 2px solid var(--navy);
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--navy);
+  padding: 0.5rem 1.1rem;
+  min-height: var(--tap-target-md);
+  font-size: 0.9rem;
+  font-weight: 600;
+  user-select: none;
+}
+
+.disclosure > summary::-webkit-details-marker {
+  display: none;                 /* Safari */
+}
+
+.disclosure > summary::marker {
+  content: '';
+}
+
+.disclosure > summary:hover {
+  background: var(--navy);
+  color: var(--surface);
+}
+
+/* summary is not a <button>, so it inherits none of the .btn focus treatment. */
+.disclosure > summary:focus-visible {
+  outline: 3px solid rgba(0,42,92,0.35);
+  outline-offset: 2px;
+}
+
+.disclosure > summary::after {
+  content: '+';
+  font-weight: 700;
+  line-height: 1;
+}
+
+.disclosure[open] > summary::after {
+  content: '\2013';
+}
+
+.disclosure-body {
+  margin-top: 1.25rem;
+  max-width: 480px;
+}
+
+/* .form-actions carries margin-top: 2rem for full-page forms — too much inside a
+   three-field disclosure. */
+.disclosure-body .form-actions {
+  margin-top: 1.25rem;
+}
+
+@media (max-width: 768px) {
+  .disclosure > summary {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .disclosure-body {
+    max-width: none;
+  }
+}
+
+/* === Reports === */
+/* No max-width: the report, member record and campaign pages all run the full content
+   width. Readability comes from capping the *fields* (.form-group--narrow) rather than
+   the page, so wide tables keep the room they need. */
+.report-page {
+  display: flow-root;
+}
+
+/* Admin flashes are styled to sit flush under the topbar — no radius, a bottom rule
+   only — so the report's pre-flight warnings rendered as a full-bleed band that ignored
+   the card grid entirely. This turns that same element into a card in the panels'
+   language. The .flash.flash-error classes stay because robot locates the warnings by
+   them. */
+.report-notice {
+  border-radius: var(--radius-card);
+  border: 1px solid #f5c6cb;
+  box-shadow: var(--shadow-card);
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1.5rem;
+}
+
+/* These are a pre-submit checklist, not a failure: mostly "add an email to this bio".
+   Amber reads as "look before you send" where the red read as "something broke". */
+.report-notice--caution {
+  background: #fff8e6;
+  color: #6b4e00;
+  border-color: #f0d9a0;
+  border-left: 4px solid #e0a12b;
+}
+
+.report-notice-title {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: #6b4e00;
+}
+
+.report-notice-list {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+.report-notice-list li {
+  margin-bottom: 0.25rem;
+}
+
+.report-notice-list li:last-child {
+  margin-bottom: 0;
+}
+
+.report-subhead {
+  color: var(--navy);
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 2rem 0 0.5rem;
+}
+
+.report-subhead + .text-muted {
+  margin-bottom: 0.75rem;
+}
+
+/* #report-summary has to stay a <table> with that id — the tests locate it by tag and
+   id — so it is restyled rather than restructured: no header fill, no rules, no hover.
+   A figure with a caption, which stops it reading as a second data table stacked on the
+   board block whose columns it could never line up with. */
+.summary-table {
+  width: auto;
+  border-collapse: collapse;
+  margin-bottom: 0.5rem;
+}
+
+/* No text-transform here. Browser library's Get Text returns *rendered* text, so
+   uppercasing these labels broke the two robot tests that assert on "Total member count"
+   and "Board members listed". The quiet-label effect comes from size, weight and colour
+   instead. */
+.summary-table th {
+  text-align: left;
+  padding: 0 1.5rem 0.5rem 0;
+  color: var(--text-subtle);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  vertical-align: baseline;
+}
+
+.summary-table td {
+  padding: 0 0 0.5rem;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--navy);
+  font-variant-numeric: tabular-nums;
+  vertical-align: baseline;
+}
+
+.report-links {
+  display: grid;
+  gap: 0.5rem;
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.report-links dt {
+  color: var(--text-subtle);
+  font-weight: 600;
+  font-size: 0.8125rem;
+}
+
+.report-links dd {
+  margin: 0.125rem 0 0;
+  overflow-wrap: anywhere;
+}
+
+.flash-list {
+  margin: 0.5rem 0 0 1.25rem;
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -7,13 +7,13 @@
 
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  color: #333;
+  color: var(--text);
   line-height: 1.6;
   overflow-anchor: none;
 }
 
 a {
-  color: #002a5c;
+  color: var(--navy);
   text-decoration: none;
 }
 
@@ -27,7 +27,7 @@ a:focus-visible,
 button:focus-visible,
 [tabindex]:focus-visible,
 summary:focus-visible {
-  outline: 3px solid #69be28;
+  outline: 3px solid var(--green);
   outline-offset: 2px;
 }
 
@@ -53,13 +53,53 @@ img {
   --nav-scroll-offset: 88px;
 }
 
+/* === Design tokens ===
+   style.css loads before admin.css, so both stylesheets resolve these. Every brand
+   colour, card radius, shadow and touch-target size used to be a repeated hex/px
+   literal — 73 colour literals alone — which is how the admin ended up with several
+   spellings of the same navy and no single place to adjust a shadow. Values are
+   unchanged from what they replaced; this is a naming pass, not a restyle. */
+:root {
+  --navy: #002a5c;
+  --navy-dark: #001d42;
+  --green: #69be28;
+  --green-light: #7ed136;
+  --danger: #dc3545;
+  --danger-dark: #c82333;
+
+  --surface: #fff;
+  --page-bg: #f0f2f5;
+
+  --text: #333;
+  --text-muted: #666;
+  --text-subtle: #6c757d;
+  --text-faint: #999;
+
+  --border: #e0e0e0;
+  --rule: #eee;
+
+  --radius-card: 8px;
+  --radius-control: 4px;
+  --shadow-card: 0 1px 3px rgba(0,0,0,0.08);
+  --shadow-card-hover: 0 3px 8px rgba(0,0,0,0.14);
+
+  /* Minimum touch targets: base control, search/pagination, small button. */
+  --tap-target: 44px;
+  --tap-target-md: 40px;
+  --tap-target-sm: 36px;
+
+  /* Readable measure for form fields. Pages themselves are not capped — admin pages run
+     the full content width and constrain their inputs instead. */
+  --measure-form: 26rem;
+}
+
 [id] {
   scroll-margin-top: var(--nav-scroll-offset);
 }
 
 /* === Navbar === */
 .navbar {
-  background: #002a5c;
+  background: var(--navy);
   display: flex;
   align-items: center;
   padding: 0 2rem;
@@ -105,7 +145,7 @@ img {
   justify-content: center;
   background: none;
   border: none;
-  color: #fff;
+  color: var(--surface);
   font-size: 24px;
   line-height: 1;
   cursor: pointer;
@@ -131,7 +171,7 @@ img {
 }
 
 .nav-menu a {
-  color: #fff;
+  color: var(--surface);
   padding: 1.25rem 1.25rem;
   display: flex;
   align-items: center;
@@ -169,7 +209,7 @@ img {
 .dropdown-caret {
   background: none;
   border: none;
-  color: #fff;
+  color: var(--surface);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -211,7 +251,7 @@ img {
   position: absolute;
   top: 100%;
   left: 0;
-  background: #002a5c;
+  background: var(--navy);
   list-style: none;
   min-width: 220px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
@@ -235,7 +275,7 @@ img {
 
 .dropdown-menu a {
   padding: 0.875rem 1.5rem;
-  min-height: 44px;
+  min-height: var(--tap-target);
 }
 
 /* === Sections === */
@@ -253,7 +293,7 @@ img {
 }
 
 .section h2 {
-  color: #002a5c;
+  color: var(--navy);
   font-size: 2.25rem;
   margin-bottom: 2rem;
   text-align: center;
@@ -267,8 +307,8 @@ img {
 
 /* === Hero === */
 .hero {
-  background: #002a5c;
-  color: #fff;
+  background: var(--navy);
+  color: var(--surface);
   text-align: center;
   padding: 7rem 2rem;
   position: relative;
@@ -311,7 +351,7 @@ img {
   z-index: 10;
   background: rgba(0, 42, 92, 0.85);
   padding: 3rem 2rem;
-  border-radius: 8px;
+  border-radius: var(--radius-card);
   max-width: 900px;
   margin: 0 auto;
 }
@@ -343,42 +383,42 @@ img {
    actual Seahawks lockup, so the brand green stays at full strength. */
 .btn {
   display: inline-block;
-  background: #69be28;
-  color: #002a5c;
+  background: var(--green);
+  color: var(--navy);
   padding: 0.75rem 1.75rem;
-  border-radius: 4px;
+  border-radius: var(--radius-control);
   font-weight: 700;
   border: none;
   cursor: pointer;
   font-size: 1rem;
   line-height: 1.5;
-  min-height: 44px;
+  min-height: var(--tap-target);
   text-align: center;
 }
 
 .btn:hover {
-  background: #7ed136;
+  background: var(--green-light);
   text-decoration: none;
-  color: #002a5c;
+  color: var(--navy);
 }
 
 .btn-outline {
   display: inline-block;
-  border: 2px solid #002a5c;
-  color: #002a5c;
+  border: 2px solid var(--navy);
+  color: var(--navy);
   background: transparent;
   padding: 0.625rem 1.75rem;
-  border-radius: 4px;
+  border-radius: var(--radius-control);
   font-weight: 600;
   font-size: 1rem;
   line-height: 1.5;
-  min-height: 44px;
+  min-height: var(--tap-target);
   text-align: center;
 }
 
 .btn-outline:hover {
-  background: #002a5c;
-  color: #fff;
+  background: var(--navy);
+  color: var(--surface);
   text-decoration: none;
 }
 
@@ -418,8 +458,8 @@ img {
 }
 
 .card {
-  background: #fff;
-  border-radius: 8px;
+  background: var(--surface);
+  border-radius: var(--radius-card);
   overflow: hidden;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
@@ -441,7 +481,7 @@ img {
 }
 
 .card-body h3 {
-  color: #002a5c;
+  color: var(--navy);
   margin-bottom: 0.75rem;
 }
 
@@ -453,7 +493,7 @@ img {
 
 /* === Blockquote === */
 blockquote {
-  border-left: 5px solid #002a5c;
+  border-left: 5px solid var(--navy);
   padding: 1.25rem 1.75rem;
   margin: 0 0 2rem;
   font-style: italic;
@@ -476,7 +516,7 @@ blockquote {
   width: 100%;
   height: 220px;
   object-fit: cover;
-  border-radius: 8px;
+  border-radius: var(--radius-card);
   transition: transform 0.2s ease;
 }
 
@@ -500,8 +540,8 @@ blockquote {
   display: block;
   max-width: 800px;
   margin: 0 auto;
-  background: #fff;
-  border-radius: 8px;
+  background: var(--surface);
+  border-radius: var(--radius-card);
   overflow: hidden;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   color: inherit;
@@ -518,7 +558,7 @@ blockquote {
 .video-card-media {
   position: relative;
   aspect-ratio: 16 / 9;
-  background: #002a5c;
+  background: var(--navy);
 }
 
 .video-card-media img {
@@ -537,7 +577,7 @@ blockquote {
   height: 76px;
   border-radius: 50%;
   background: rgba(0, 42, 92, 0.88);
-  border: 3px solid #fff;
+  border: 3px solid var(--surface);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -549,16 +589,16 @@ blockquote {
   content: '';
   border-style: solid;
   border-width: 13px 0 13px 21px;
-  border-color: transparent transparent transparent #fff;
+  border-color: transparent transparent transparent var(--surface);
   margin-left: 5px;
 }
 
 .video-card:hover .video-card-play {
-  background: #69be28;
+  background: var(--green);
 }
 
 .video-card:hover .video-card-play::after {
-  border-left-color: #002a5c;
+  border-left-color: var(--navy);
 }
 
 .video-card-body {
@@ -579,7 +619,7 @@ blockquote {
 .video-card-title {
   font-size: 1.15rem;
   font-weight: 700;
-  color: #002a5c;
+  color: var(--navy);
   line-height: 1.4;
 }
 
@@ -608,7 +648,7 @@ blockquote {
   display: block;
   margin-bottom: 0.5rem;
   font-weight: 600;
-  color: #002a5c;
+  color: var(--navy);
   font-size: 1rem;
 }
 
@@ -617,11 +657,11 @@ blockquote {
   width: 100%;
   padding: 0.875rem 1rem;
   border: 1px solid #ccc;
-  border-radius: 4px;
+  border-radius: var(--radius-control);
   font-size: 1rem;
   font-family: inherit;
   line-height: 1.5;
-  min-height: 44px;
+  min-height: var(--tap-target);
 }
 
 .form-group textarea {
@@ -632,7 +672,7 @@ blockquote {
 .form-group input:focus,
 .form-group textarea:focus {
   outline: none;
-  border-color: #002a5c;
+  border-color: var(--navy);
   box-shadow: 0 0 0 3px rgba(0, 42, 92, 0.1);
 }
 
@@ -647,9 +687,9 @@ blockquote {
 .bio-card {
   display: block;
   width: 100%;
-  background: #fff;
+  background: var(--surface);
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius-card);
   padding: 2rem 1.5rem;
   text-align: center;
   font-family: inherit;
@@ -667,7 +707,7 @@ blockquote {
 }
 
 .bio-card:focus-visible {
-  outline: 3px solid #69be28;
+  outline: 3px solid var(--green);
   outline-offset: 2px;
 }
 
@@ -680,13 +720,13 @@ blockquote {
 }
 
 .bio-card h3 {
-  color: #002a5c;
+  color: var(--navy);
   margin-bottom: 0.5rem;
   font-size: 1.25rem;
 }
 
 /* Green reads as "you can act on this" everywhere else, so a role label uses the
-   darker text green — #69be28 on white is only 2.33:1 in any case. */
+   darker text green — var(--green) on white is only 2.33:1 in any case. */
 .bio-role {
   color: #4a7d1d;
   font-weight: 600;
@@ -719,8 +759,8 @@ blockquote {
 
 .bio-modal-dialog {
   position: relative;
-  background: #fff;
-  border-radius: 8px;
+  background: var(--surface);
+  border-radius: var(--radius-card);
   padding: 2.5rem;
   max-width: 560px;
   width: 100%;
@@ -743,7 +783,7 @@ blockquote {
 }
 
 .bio-modal-close:hover {
-  color: #002a5c;
+  color: var(--navy);
 }
 
 .bio-modal-photo {
@@ -755,7 +795,7 @@ blockquote {
 }
 
 .bio-modal-name {
-  color: #002a5c;
+  color: var(--navy);
   margin-bottom: 0.5rem;
   font-size: 1.5rem;
 }
@@ -777,8 +817,8 @@ blockquote {
 
 /* === Footer === */
 footer {
-  background: #002a5c;
-  color: #fff;
+  background: var(--navy);
+  color: var(--surface);
   padding: 4rem 2rem 1.5rem;
 }
 
@@ -810,13 +850,13 @@ footer {
 }
 
 .footer-section a {
-  color: #69be28;
+  color: var(--green);
   padding: 0.25rem 0;
   display: inline-block;
 }
 
 .footer-section a:hover {
-  color: #fff;
+  color: var(--surface);
 }
 
 .footer-bottom {
@@ -829,7 +869,7 @@ footer {
 }
 
 .footer-bottom a {
-  color: #69be28;
+  color: var(--green);
 }
 
 .social-links {
@@ -839,7 +879,7 @@ footer {
 }
 
 .social-link svg {
-    fill: #69be28;
+    fill: var(--green);
     width: 28px;
     height: 28px;
     transition: fill 0.2s;
@@ -847,7 +887,7 @@ footer {
 }
 
 .social-link:hover svg {
-    fill: #fff;
+    fill: var(--surface);
 }
 
 /* === Flash Messages === */
@@ -888,8 +928,8 @@ footer {
 }
 
 .membership-benefits {
-  background: #002a5c;
-  color: #fff;
+  background: var(--navy);
+  color: var(--surface);
   border-radius: 10px;
   padding: 3rem 2.5rem;
   display: flex;
@@ -898,7 +938,7 @@ footer {
 }
 
 .membership-benefits h2 {
-  color: #fff;
+  color: var(--surface);
   font-size: 1.65rem;
   margin-bottom: 0.4rem;
   text-align: left;
@@ -926,8 +966,8 @@ footer {
 .benefit-icon {
   width: 26px;
   height: 26px;
-  background: #69be28;
-  color: #fff;
+  background: var(--green);
+  color: var(--surface);
   border-radius: 50%;
   display: flex;
   align-items: center;
@@ -968,14 +1008,14 @@ footer {
 
 /* Form panel */
 .membership-form-panel {
-  background: #fff;
+  background: var(--surface);
   border-radius: 10px;
   padding: 2.5rem 2.5rem 3rem;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.07);
 }
 
 .membership-form-panel h2 {
-  color: #002a5c;
+  color: var(--navy);
   font-size: 1.65rem;
   margin-bottom: 1.75rem;
   text-align: left;
@@ -986,7 +1026,7 @@ footer {
   display: flex;
   gap: 0;
   margin-bottom: 1.75rem;
-  border-bottom: 2px solid #e0e0e0;
+  border-bottom: 2px solid var(--border);
 }
 
 .membership-tab {
@@ -1004,12 +1044,12 @@ footer {
 }
 
 .membership-tab:hover {
-  color: #002a5c;
+  color: var(--navy);
 }
 
 .membership-tab-active {
-  color: #002a5c;
-  border-bottom-color: #002a5c;
+  color: var(--navy);
+  border-bottom-color: var(--navy);
 }
 
 /* Form section heading */
@@ -1021,7 +1061,7 @@ footer {
   color: #6b6b6b;
   margin-bottom: 0.875rem;
   padding-bottom: 0.5rem;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--rule);
 }
 
 /* Membership type cards */
@@ -1039,24 +1079,24 @@ footer {
     display: flex;
     align-items: flex-start;
     gap: 0.75rem;
-  border: 2px solid #e0e0e0;
-  border-radius: 8px;
+  border: 2px solid var(--border);
+  border-radius: var(--radius-card);
     padding: 1.1rem;
   cursor: pointer;
   transition: border-color 0.15s ease, background 0.15s ease;
 }
 
 .membership-type-card:hover {
-  border-color: #002a5c;
+  border-color: var(--navy);
 }
 
 .membership-type-card:has(input[type="radio"]:checked) {
-  border-color: #002a5c;
+  border-color: var(--navy);
   background: rgba(0, 42, 92, 0.03);
 }
 
 .membership-type-card:has(input[type="radio"]:focus-visible) {
-    outline: 3px solid #69be28;
+    outline: 3px solid var(--green);
     outline-offset: 2px;
 }
 
@@ -1065,7 +1105,7 @@ footer {
     height: 22px;
     margin: 0;
     flex-shrink: 0;
-    accent-color: #002a5c;
+    accent-color: var(--navy);
     cursor: pointer;
 }
 
@@ -1077,7 +1117,7 @@ footer {
 
 .card-type-name {
   font-weight: 700;
-  color: #002a5c;
+  color: var(--navy);
   font-size: 0.875rem;
   margin-bottom: 0.25rem;
   text-transform: uppercase;
@@ -1087,7 +1127,7 @@ footer {
 .card-type-price {
   font-size: 1.5rem;
   font-weight: 700;
-  color: #002a5c;
+  color: var(--navy);
   margin-bottom: 0.2rem;
   line-height: 1.2;
 }
@@ -1176,7 +1216,7 @@ footer {
 
 .family-member-legend {
     font-weight: 700;
-    color: #002a5c;
+    color: var(--navy);
     font-size: 0.95rem;
 }
 
@@ -1238,7 +1278,7 @@ footer {
     top: 100%;
     left: 0;
     right: 0;
-    background: #002a5c;
+    background: var(--navy);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
     /* Not calc(100vh - 100%): the percentage resolves against .navbar, whose height is
        content-derived, so the max-height would be indeterminate and the scroll would
@@ -1423,8 +1463,8 @@ footer {
 
 .hw-modal-dialog {
   position: relative;
-  background: #fff;
-  border-radius: 8px;
+  background: var(--surface);
+  border-radius: var(--radius-card);
   padding: 2rem;
   max-width: 360px;
   width: 90%;
@@ -1432,14 +1472,14 @@ footer {
 }
 
 .hw-modal-dialog h3 {
-  color: #002a5c;
+  color: var(--navy);
   margin-bottom: 1rem;
 }
 
 .hw-modal-dialog address {
   font-style: normal;
   line-height: 1.8;
-  color: #333;
+  color: var(--text);
   font-size: 1rem;
 }
 
@@ -1456,7 +1496,7 @@ footer {
 }
 
 .hw-modal-close:hover {
-  color: #002a5c;
+  color: var(--navy);
 }
 
 /* === Man Crush Monday === */
@@ -1473,12 +1513,12 @@ footer {
     margin: 0 auto;
     padding: 1.75rem 2rem;
     background: #f8f8f8;
-    border-left: 5px solid #69be28;
+    border-left: 5px solid var(--green);
     border-radius: 0 8px 8px 0;
 }
 
 .mcm-curator h3 {
-    color: #002a5c;
+    color: var(--navy);
     margin-bottom: 0.75rem;
 }
 
@@ -1489,7 +1529,7 @@ footer {
 }
 
 .mcm-wall-heading {
-    color: #002a5c;
+    color: var(--navy);
     text-align: center;
     margin-bottom: 2rem;
 }
@@ -1503,7 +1543,7 @@ footer {
 /* Brass frame: a gradient border painted under a transparent border box. */
 .mcm-frame {
     border: 10px solid transparent;
-    border-radius: 4px;
+    border-radius: var(--radius-control);
     background-image: linear-gradient(#f4efe2, #f4efe2),
     linear-gradient(145deg, #d9b45e 0%, #f3e2a8 25%, #b8912f 55%, #f0dc9c 80%, #c9a141 100%);
     background-origin: border-box;
@@ -1521,7 +1561,7 @@ footer {
     width: 100%;
     aspect-ratio: 4 / 5;
     object-fit: cover;
-    background: #002a5c;
+    background: var(--navy);
     border: 1px solid rgba(0, 0, 0, 0.25);
 }
 
@@ -1564,7 +1604,7 @@ footer {
 
 .mcm-frame--signing {
     background-image: linear-gradient(#f4efe2, #f4efe2),
-    linear-gradient(145deg, #69be28 0%, #b7e78c 30%, #4f9418 60%, #a4dd76 85%, #69be28 100%);
+    linear-gradient(145deg, var(--green) 0%, #b7e78c 30%, #4f9418 60%, #a4dd76 85%, var(--green) 100%);
 }
 
 .mcm-frame--signing .mcm-plaque {
@@ -1581,7 +1621,7 @@ footer {
 
 .mcm-end {
     font-style: italic;
-    color: #002a5c;
+    color: var(--navy);
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/public/js/admin-member-form.js
+++ b/public/js/admin-member-form.js
@@ -9,7 +9,9 @@
 
     radios.forEach(function (radio) {
         radio.addEventListener('change', function () {
-            familySection.style.display = radio.value === 'family' ? 'block' : 'none';
+            // Matches membership.js: toggle the attribute the markup ships with,
+            // rather than layering an inline display over it.
+            familySection.hidden = radio.value !== 'family';
         });
     });
 

--- a/robot/libraries/DatabaseManager.py
+++ b/robot/libraries/DatabaseManager.py
@@ -205,23 +205,30 @@ class DatabaseManager:
                     phone=None, status='active', membership_year=2026,
                     member_number=None, address_street=None, address_city=None,
                     address_state='MT', address_zip=None, notes=None,
-                    expiry_date=None):
+                    expiry_date=None, membership_type='individual'):
         """Insert a member and return the row ID."""
         if email is None:
             import random
             email = f'test{random.randint(10000, 99999)}@example.com'
         if member_number is None:
-            count = self.conn.execute('SELECT COUNT(*) FROM members').fetchone()[0]
+            # Count within the year, matching services/members.generateMemberNumber. A
+            # total COUNT(*) drifts out of step with it as soon as any row has a
+            # different membership_year (the seeded admin, for one), and the two schemes
+            # then collide on the same number the moment the app creates a member itself.
+            count = self.conn.execute(
+                'SELECT COUNT(*) FROM members WHERE membership_year = ?',
+                (membership_year,),
+            ).fetchone()[0]
             member_number = f'YSH-{membership_year}-{str(count + 1).zfill(4)}'
         cursor = self.conn.execute(
             '''INSERT INTO members
                (member_number, first_name, last_name, email, phone,
                 address_street, address_city, address_state, address_zip,
-                membership_year, status, notes, expiry_date)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+                membership_year, status, notes, expiry_date, membership_type)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
             (member_number, first_name, last_name, email, phone,
              address_street, address_city, address_state, address_zip,
-             membership_year, status, notes, expiry_date),
+             membership_year, status, notes, expiry_date, membership_type),
         )
         self.conn.commit()
         return cursor.lastrowid

--- a/robot/tests/admin_members.robot
+++ b/robot/tests/admin_members.robot
@@ -143,3 +143,80 @@ Needs Attention Export Includes Signals
     Should Contain    ${csv}    Signals
     Should Contain    ${csv}    Stripe reported a failed payment
     Should Contain    ${csv}    declined@example.com
+
+Record Offline Payment Disclosure Reveals The Form
+    [Documentation]    Operates the <details> control itself. The "hidden" assertion first is
+    ...    load-bearing: a test that only fills the form passes just as well when the
+    ...    disclosure is stuck open or absent entirely. Also pins the dues prefill, which the
+    ...    route computed but the template never used.
+    Seed Period
+    ${id}=    Seed Member    first_name=Owen    last_name=Offline    email=owen@example.com    status=pending
+    Login As Admin
+    Navigate To    /admin/members/${id}
+    Wait For Elements State    input#amount    hidden    timeout=10s
+    Click    summary >> text=Record Offline Payment
+    Wait For Elements State    input#amount    visible    timeout=10s
+    ${amount}=    Get Property    input#amount    value
+    Should Match Regexp    ${amount}    ^\\d+\\.\\d{2}$
+    Fill Text    input#amount    25.00
+    Click    form#record-payment button[type="submit"]
+    Flash Success Should Be Visible    recorded
+    Get Text    table#member-payments    contains    25.00
+
+Add Family Member Disclosure Reveals The Form
+    [Documentation]    Same shape as the offline-payment disclosure: assert hidden, operate the
+    ...    control, then submit through it.
+    ${id}=    Seed Member    first_name=Fran    last_name=Primary    email=fran@example.com    membership_type=family
+    Login As Admin
+    Navigate To    /admin/members/${id}
+    Wait For Elements State    input#fm_first_name    hidden    timeout=10s
+    Click    summary >> text=Add Family Member
+    Wait For Elements State    input#fm_first_name    visible    timeout=10s
+    Fill Text    input#fm_first_name    Kid
+    Fill Text    input#fm_last_name    Primary
+    Fill Text    input#fm_email    kid@example.com
+    Click    form#add-family-member button[type="submit"]
+    Flash Success Should Be Visible    Family member Kid Primary added
+    Get Text    .detail-table    contains    Kid Primary
+
+Attach To Family Disclosure Reveals The Form
+    ${primary}=    Seed Member    first_name=Hank    last_name=Household    email=hank@example.com    membership_type=family
+    ${solo}=    Seed Member    first_name=Sam    last_name=Solo    email=sam@example.com
+    Login As Admin
+    Navigate To    /admin/members/${solo}
+    Wait For Elements State    select#primary_member_id    hidden    timeout=10s
+    Click    summary >> text=Attach to Family
+    Wait For Elements State    select#primary_member_id    visible    timeout=10s
+    ${primary_value}=    Convert To String    ${primary}
+    Select Options By    select#primary_member_id    value    ${primary_value}
+    Click    form#attach-family button[type="submit"]
+    Flash Success Should Be Visible    attached to Hank Household's family
+    Get Text    .detail-table    contains    Hank Household
+
+Failed Offline Payment Reopens The Disclosure
+    [Documentation]    A red banner above a collapsed control would be worse than the old
+    ...    always-expanded form, so a validation failure re-opens the panel it came from.
+    ${id}=    Seed Member    first_name=Bad    last_name=Amount    email=bad@example.com
+    Login As Admin
+    Navigate To    /admin/members/${id}
+    Click    summary >> text=Record Offline Payment
+    Wait For Elements State    input#amount    visible    timeout=10s
+    # The input carries min="0.01", so the browser refuses to submit and the server-side
+    # branch under test is never reached. Disable client validation for this submit only.
+    Evaluate JavaScript    form#record-payment    (f) => { f.noValidate = true; }
+    Fill Text    input#amount    0
+    Click    form#record-payment button[type="submit"]
+    Flash Error Should Be Visible    valid payment amount
+    Wait For Elements State    input#amount    visible    timeout=10s
+
+Member Actions Sit On One Row
+    [Documentation]    The buttons used to be wrapped in style="display:inline", which kept them
+    ...    out of the flex line and split them across two ragged rows. Asserts they share a
+    ...    single row at desktop width.
+    ${id}=    Seed Member    first_name=Row    last_name=Aligned    email=row@example.com
+    Login As Admin
+    Set Viewport Size    1440    900
+    Navigate To    /admin/members/${id}
+    ${rows}=    Evaluate JavaScript    ${None}
+    ...    () => new Set([...document.querySelectorAll('.record-actionbar button, .record-actionbar a.btn')].map(el => Math.round(el.getBoundingClientRect().top))).size
+    Should Be Equal As Integers    ${rows}    1

--- a/robot/tests/admin_settings.robot
+++ b/robot/tests/admin_settings.robot
@@ -40,3 +40,19 @@ Dashboard Shows Statistics
     Login As Admin
     Navigate To    /admin/dashboard
     Get Text    .stats-grid    contains    2
+
+KPI Values Stay Inside Their Cards
+    [Documentation]    The regression guard for the reported defect: "$2034.00" at a fixed
+    ...    2.25rem was wider than the card's content box and painted outside it. A text
+    ...    assertion cannot see that, so this compares scroll width against client width on
+    ...    every tile — the only check that would have caught it. Seeds a large revenue figure
+    ...    because the overflow only shows up once the number is long.
+    ${id}=    Seed Member    first_name=Big    last_name=Spender    email=big@example.com
+    Seed Payment    member_id=${id}    amount_cents=98765432
+    Login As Admin
+    Navigate To    /admin/dashboard
+    Wait For Elements State    .stats-grid    visible    timeout=10s
+    ${overflowing}=    Evaluate JavaScript    ${None}
+    ...    () => [...document.querySelectorAll('.stat-card')].filter(c => c.scrollWidth > c.clientWidth).length
+    Should Be Equal As Integers    ${overflowing}    0
+

--- a/routes/admin.js
+++ b/routes/admin.js
@@ -464,10 +464,16 @@ router.get('/members/:id', async (req, res, next) => {
       familyPrimaries = await memberRepo.listFamilyPrimaries();
     }
 
+    // Prefills the offline-payment amount. duesForType returns undefined when a period
+    // has no dues set for the type, and centsToDollars(undefined) yields the string
+    // "NaN" — which would render as value="NaN" and fail number validation silently.
     const currentPeriod = await periodsRepo.getCurrent();
     const {duesForType, centsToDollars} = membershipPeriodsService;
-    const defaultPaymentDollars = currentPeriod
-        ? centsToDollars(duesForType(currentPeriod, member.membership_type))
+    const duesCents = currentPeriod
+        ? duesForType(currentPeriod, member.membership_type)
+        : null;
+    const defaultPaymentDollars = Number.isFinite(duesCents)
+        ? centsToDollars(duesCents)
         : '';
 
     res.render('admin/members/view', {
@@ -672,6 +678,7 @@ router.post('/members/:id/payments', async (req, res) => {
   const dollars = parseFloat(amount);
   if (!amount || isNaN(dollars) || dollars <= 0) {
     req.session.flash_error = 'A valid payment amount is required.';
+    req.session.flash_reopen = 'record-payment';
     return res.redirect(`/admin/members/${req.params.id}`);
   }
 
@@ -768,11 +775,13 @@ router.post('/members/:id/attach-to-family', async (req, res) => {
   const {primary_member_id} = req.body;
   if (!primary_member_id) {
     req.session.flash_error = 'Please select a family to attach to.';
+    req.session.flash_reopen = 'attach-family';
     return res.redirect(`/admin/members/${req.params.id}`);
   }
   const primary = await memberRepo.findById(primary_member_id);
   if (!primary || primary.membership_type !== 'family' || primary.primary_member_id) {
     req.session.flash_error = 'Invalid primary member selected.';
+    req.session.flash_reopen = 'attach-family';
     return res.redirect(`/admin/members/${req.params.id}`);
   }
   try {
@@ -780,6 +789,7 @@ router.post('/members/:id/attach-to-family', async (req, res) => {
     req.session.flash_success = `${member.first_name} ${member.last_name} attached to ${primary.first_name} ${primary.last_name}'s family.`;
   } catch (e) {
     req.session.flash_error = e.message;
+    req.session.flash_reopen = 'attach-family';
   }
   res.redirect(`/admin/members/${req.params.id}`);
 });
@@ -798,6 +808,7 @@ router.post('/members/:id/family-members', async (req, res) => {
   const {first_name, last_name, email} = req.body;
   if (!first_name?.trim() || !last_name?.trim()) {
     req.session.flash_error = 'First and last name are required.';
+    req.session.flash_reopen = 'add-family-member';
     return res.redirect(`/admin/members/${req.params.id}`);
   }
   try {
@@ -811,6 +822,7 @@ router.post('/members/:id/family-members', async (req, res) => {
     req.session.flash_success = `Family member ${first_name.trim()} ${last_name.trim()} added.`;
   } catch (e) {
     req.session.flash_error = e.message;
+    req.session.flash_reopen = 'add-family-member';
   }
   res.redirect(`/admin/members/${req.params.id}`);
 });

--- a/test/middleware/locals.test.js
+++ b/test/middleware/locals.test.js
@@ -148,3 +148,43 @@ describe('formatDate helper', () => {
     expect(formatDate('2024-01-15')).toBe('2024-01-15');
   });
 });
+
+describe('money helpers', () => {
+  let formatMoney, formatMoneyShort;
+
+  beforeEach(async () => {
+    const res = buildRes();
+    await injectLocals(buildReq(), res, jest.fn());
+    formatMoney = res.locals.formatMoney;
+    formatMoneyShort = res.locals.formatMoneyShort;
+  });
+
+  test('formats cents as exact dollars', () => {
+    expect(formatMoney(0)).toBe('$0.00');
+    expect(formatMoney(2550)).toBe('$25.50');
+  });
+
+  test('groups thousands, which the old toFixed(2) did not', () => {
+    expect(formatMoney(203400)).toBe('$2,034.00');
+    expect(formatMoney(123456789)).toBe('$1,234,567.89');
+  });
+
+  // sumCompletedCents() returns null on an empty payments table.
+  test('treats null and undefined as zero', () => {
+    expect(formatMoney(null)).toBe('$0.00');
+    expect(formatMoney(undefined)).toBe('$0.00');
+  });
+
+  test('short form drops .00 on whole amounts so KPI tiles stay narrow', () => {
+    expect(formatMoneyShort(203400)).toBe('$2,034');
+    expect(formatMoneyShort(0)).toBe('$0');
+  });
+
+  test('short form keeps the cents when there are any', () => {
+    expect(formatMoneyShort(2550)).toBe('$25.50');
+  });
+
+  test('short form treats null as zero', () => {
+    expect(formatMoneyShort(null)).toBe('$0');
+  });
+});

--- a/test/routes/admin-council-report-http.test.js
+++ b/test/routes/admin-council-report-http.test.js
@@ -91,6 +91,28 @@ describe('GET /admin/reports/membership', () => {
     expect(res.text).toContain('Chief Hype Officer');
     expect(res.text).toContain('Board members listed');
   });
+
+  test('keeps the summary a summary and the no-JS fallback in place', async () => {
+    insertAdmin(db, { email: 'admin@ysh.test', first_name: 'Ada', last_name: 'Admin' });
+    const member = insertMember(db, { email: 'member@ysh.test' });
+    await membershipYearsRepo.enroll(member.id, period.id, null);
+
+    const agent = await loginAsAdmin('admin@ysh.test');
+    const res = await agent.get(`/admin/reports/membership?period=${period.id}`).expect(200);
+
+    // The social links moved out to their own list. They used to be extra rows in the
+    // summary table, which is what made it read as a second data table stacked on the
+    // board block whose columns it could never line up with.
+    // Pug emits class before id, so match on the id anywhere in the opening tag.
+    const summary = res.text.match(/<table[^>]*id="report-summary"[\s\S]*?<\/table>/)[0];
+    expect(summary).toContain('Total member count');
+    expect(summary).not.toContain('facebook.com');
+    expect(res.text).toContain('facebook.com');
+
+    // data-auto-submit is JavaScript, and this path has silently died once already under
+    // helmet's script-src-attr 'none'. The button is the fallback; keep it.
+    expect(res.text).toContain('id="apply-period"');
+  });
 });
 
 describe('GET /admin/reports/membership/download', () => {

--- a/test/routes/admin-payments-http.test.js
+++ b/test/routes/admin-payments-http.test.js
@@ -1,0 +1,132 @@
+/**
+ * HTTP integration test for the payments list and the dashboard's Recent Payments panel:
+ * the real Express app, a real admin login and real Pug rendering, with only the database
+ * swapped for the in-memory SQLite proxy.
+ *
+ * These pages had no rendered-HTML coverage at all, which is how the member column stayed
+ * unlinked. The point of these tests is to pin the href.
+ */
+process.env.NODE_ENV = 'test';
+
+jest.mock('../../db/database', () => require('../helpers/setupDb'));
+jest.mock('../../services/email', () => ({
+  sendOtpEmail: jest.fn().mockResolvedValue({}),
+}));
+
+const request = require('supertest');
+const app = require('../../server');
+const db = require('../../db/database');
+const { insertMember, insertAdmin, insertPayment, insertPeriod } = require('../helpers/fixtures');
+
+const TEST_OTP = '000000';
+
+function tokenFrom(html) {
+  const match = html.match(/name="_csrf" value="([^"]+)"/);
+  if (!match) throw new Error('No CSRF token in response');
+  return match[1];
+}
+
+async function loginAsAdmin(email) {
+  const agent = request.agent(app);
+  const loginPage = await agent.get('/admin/login').expect(200);
+  await agent.post('/admin/login')
+    .type('form')
+    .send({ _csrf: tokenFrom(loginPage.text), email })
+    .expect(302);
+  const verifyPage = await agent.get('/admin/login/verify').expect(200);
+  await agent.post('/admin/login/verify')
+    .type('form')
+    .send({ _csrf: tokenFrom(verifyPage.text), code: TEST_OTP })
+    .expect(302);
+  return agent;
+}
+
+let testDb;
+let agent;
+
+beforeEach(async () => {
+  db.__resetTestDb();
+  testDb = db.__getCurrentDb();
+  insertAdmin(testDb, { email: 'admin@ysh.test', first_name: 'Ada', last_name: 'Admin' });
+  agent = await loginAsAdmin('admin@ysh.test');
+});
+
+describe('GET /admin/payments', () => {
+  test('links the member name back to the member record', async () => {
+    const member = insertMember(testDb, {
+      first_name: 'Adam', last_name: 'Emmert', email: 'adam@example.com',
+    });
+    insertPayment(testDb, { member_id: member.id, amount_cents: 1600 });
+
+    const res = await agent.get('/admin/payments').expect(200);
+
+    expect(res.text).toContain(`<a href="/admin/members/${member.id}">Adam Emmert</a>`);
+  });
+
+  test('formats the amount with thousands separators', async () => {
+    const member = insertMember(testDb, { email: 'big@example.com' });
+    insertPayment(testDb, { member_id: member.id, amount_cents: 203400 });
+
+    const res = await agent.get('/admin/payments').expect(200);
+
+    expect(res.text).toContain('$2,034.00');
+  });
+
+  // member_id is NOT NULL, so the only way first_name goes missing is a vanished member
+  // row — which is exactly the case an id-only link would send an admin to a 404.
+  test('renders N/A without a link when the joined member row is missing', async () => {
+    const member = insertMember(testDb, { email: 'gone@example.com' });
+    insertPayment(testDb, { member_id: member.id });
+    testDb.prepare('PRAGMA foreign_keys = OFF').run();
+    testDb.prepare('DELETE FROM members WHERE id = ?').run(member.id);
+
+    const res = await agent.get('/admin/payments').expect(200);
+
+    expect(res.text).toContain('N/A');
+    expect(res.text).not.toContain('/admin/members/null');
+    expect(res.text).not.toContain('/admin/members/undefined');
+    expect(res.text).not.toContain(`/admin/members/${member.id}`);
+  });
+});
+
+describe('GET /admin/dashboard', () => {
+  test('links the member name in Recent Payments, like Recent Members above it', async () => {
+    const member = insertMember(testDb, {
+      first_name: 'Dustin', last_name: 'Sanders', email: 'dustin@example.com',
+    });
+    insertPayment(testDb, { member_id: member.id, amount_cents: 1600 });
+
+    const res = await agent.get('/admin/dashboard').expect(200);
+
+    expect(res.text).toContain(`<a href="/admin/members/${member.id}">Dustin Sanders</a>`);
+  });
+
+  // admin_auth.robot counts exactly 7 of these, and admin.resource waits on .stats-grid
+  // as its "login finished" signal. The seventh tile is the current-period enrollment,
+  // which only renders when a period covers today — hence the seeded period.
+  test('keeps the seven KPI tiles inside .stats-grid', async () => {
+    const today = new Date().toISOString().slice(0, 10);
+    insertPeriod(testDb, { start_date: today, end_date: '2099-12-31' });
+
+    const res = await agent.get('/admin/dashboard').expect(200);
+
+    expect(res.text).toContain('class="stats-grid"');
+    expect(res.text.match(/class="stat-card"/g) || []).toHaveLength(7);
+  });
+
+  test('omits the enrollment tile when no period covers today', async () => {
+    const res = await agent.get('/admin/dashboard').expect(200);
+
+    expect(res.text.match(/class="stat-card"/g) || []).toHaveLength(6);
+  });
+
+  test('renders revenue in the short form so it cannot outgrow its card', async () => {
+    const member = insertMember(testDb, { email: 'rev@example.com' });
+    insertPayment(testDb, { member_id: member.id, amount_cents: 203400, status: 'completed' });
+
+    const res = await agent.get('/admin/dashboard').expect(200);
+
+    expect(res.text).toContain('$2,034<');
+    expect(res.text).not.toContain('$2034.00');
+  });
+});

--- a/views/admin/admins.pug
+++ b/views/admin/admins.pug
@@ -22,9 +22,7 @@ block content
           td= admin.role === 'super_admin' ? 'Super Admin' : 'Editor'
           td= formatDate(admin.created_at)
           td
-            form(method="POST" action=`/admin/admins/${admin.id}/delete` style="display:inline" data-confirm="Demote this admin?")
-              input(type="hidden" name="_csrf" value=csrfToken)
-              button.btn.btn-sm.btn-danger(type="submit") Demote
+            +confirmForm(`/admin/admins/${admin.id}/delete`, 'Demote this admin?', 'Demote', true)
 
   hr
 

--- a/views/admin/announcements/form.pug
+++ b/views/admin/announcements/form.pug
@@ -18,9 +18,7 @@ block content
       label(for="image") Image
       input#image(type="file" name="image" accept="image/*")
       if announcement && announcement.image_path
-        .image-preview
-          img(src=announcement.image_path alt="Current image" style="max-height:120px; margin-top:0.5rem")
-          input(type="hidden" name="existing_image" value=announcement.image_path)
+        +imagePreview(announcement.image_path, 'existing_image', 'Current image')
     .form-group
       label(for="link_url") Link URL
       input#link_url(type="url" name="link_url" value=(announcement ? announcement.link_url : ''))

--- a/views/admin/announcements/list.pug
+++ b/views/admin/announcements/list.pug
@@ -22,8 +22,6 @@ block content
             td= ann.is_published ? 'Yes' : 'No'
             td= ann.sort_order
             td
-              a.btn-sm(href=`/admin/announcements/${ann.id}`) Edit
-              form(method="POST" action=`/admin/announcements/${ann.id}/delete` style="display:inline" data-confirm="Delete this announcement?")
-                button.btn-sm.btn-danger(type="submit") Delete
+              +rowActions(`/admin/announcements/${ann.id}`, `/admin/announcements/${ann.id}/delete`, 'Delete this announcement?')
   else
     p.text-muted No announcements yet.

--- a/views/admin/audit.pug
+++ b/views/admin/audit.pug
@@ -4,83 +4,6 @@ block page_title
     | Audit Log
 
 block content
-    style.
-        .audit-filters {
-            margin-bottom: 1rem;
-            display: flex;
-            align-items: center;
-            gap: .75rem;
-        }
-
-        .audit-filters select {
-            padding: .3rem .5rem;
-            border: 1px solid #ccc;
-            border-radius: 4px;
-        }
-
-        .audit-meta {
-            color: #666;
-            font-size: .875rem;
-            margin-bottom: .5rem;
-        }
-
-        .audit-ts {
-            white-space: nowrap;
-            font-size: .8rem;
-            color: #555;
-        }
-
-        .audit-json {
-            max-height: 300px;
-            overflow: auto;
-            background: #f8f8f8;
-            border: 1px solid #ddd;
-            border-radius: 4px;
-            padding: .5rem;
-            font-size: .75rem;
-            white-space: pre-wrap;
-        }
-
-        .audit-diff {
-            width: 100%;
-            border-collapse: collapse;
-            font-size: .8rem;
-            margin-top: .4rem;
-        }
-
-        .audit-diff th, .audit-diff td {
-            padding: .2rem .5rem;
-            border: 1px solid #e5e7eb;
-        }
-
-        .audit-diff th {
-            background: #f3f4f6;
-            font-weight: 600;
-        }
-
-        .audit-old {
-            color: #991b1b;
-            background: #fff5f5;
-            word-break: break-all;
-        }
-
-        .audit-new {
-            color: #065f46;
-            background: #f0fff4;
-            word-break: break-all;
-        }
-
-        .muted {
-            color: #888;
-            font-size: .85rem;
-        }
-
-        details summary {
-            cursor: pointer;
-            font-size: .85rem;
-            color: #4b5563;
-        }
-
     .audit-filters
         form(method="GET" action="/admin/audit")
             label(for="table-filter") Table:
@@ -116,7 +39,7 @@ block content
                             td
                                 code= entry.record_id
                             td
-                                span(class=`audit-badge audit-badge--${entry.action.toLowerCase()}`)= entry.action
+                                +badge(`audit-${entry.action.toLowerCase()}`, entry.action)
                             td= entry.actor_email || '(system)'
                             td
                                 if entry.action === 'INSERT' && newObj
@@ -129,7 +52,7 @@ block content
                                         pre.audit-json= JSON.stringify(oldObj, null, 2)
                                 else if entry.action === 'UPDATE'
                                     if changedKeys.length === 0
-                                        span.muted (no field changes)
+                                        span.text-muted (no field changes)
                                     else
                                         details
                                             summary #{changedKeys.length} field(s) changed
@@ -149,11 +72,5 @@ block content
                                 else
                                     span —
 
-    if totalPages > 1
-        .pagination
-            if page > 1
-                a(href=`/admin/audit?page=${page - 1}&table=${tableName}`) &laquo; Prev
-            span Page #{page} of #{totalPages}
-            if page < totalPages
-                a(href=`/admin/audit?page=${page + 1}&table=${tableName}`) Next &raquo;
+    +pagination(page, totalPages, null, (n) => `/admin/audit?page=${n}&table=${tableName}`)
 

--- a/views/admin/bios/form.pug
+++ b/views/admin/bios/form.pug
@@ -25,9 +25,7 @@ block content
       label(for="image") Photo
       input#image(type="file" name="image" accept="image/*")
       if bio && bio.photo_path
-        .image-preview
-          img(src=bio.photo_path alt="Current photo" style="max-height:120px; margin-top:0.5rem; border-radius:50%")
-          input(type="hidden" name="existing_photo" value=bio.photo_path)
+        +imagePreview(bio.photo_path, 'existing_photo', 'Current photo', true)
     .form-grid
       .form-group
         label(for="sort_order") Sort Order

--- a/views/admin/bios/list.pug
+++ b/views/admin/bios/list.pug
@@ -22,14 +22,12 @@ block content
           tr
             td
               if bio.photo_path
-                img(src=bio.photo_path alt=bio.name style="width:40px; height:40px; border-radius:50%; object-fit:cover")
+                img.avatar-sm(src=bio.photo_path alt=bio.name)
             td: a(href=`/admin/bios/${bio.id}`)= bio.name
             td= bio.role || '—'
             td= bio.is_visible ? 'Yes' : 'No'
             td= bio.sort_order
             td
-              a.btn-sm(href=`/admin/bios/${bio.id}`) Edit
-              form(method="POST" action=`/admin/bios/${bio.id}/delete` style="display:inline" data-confirm="Delete this bio?")
-                button.btn-sm.btn-danger(type="submit") Delete
+              +rowActions(`/admin/bios/${bio.id}`, `/admin/bios/${bio.id}/delete`, 'Delete this bio?')
   else
     p.text-muted No bios yet.

--- a/views/admin/campaigns/detail.pug
+++ b/views/admin/campaigns/detail.pug
@@ -4,103 +4,110 @@ block page_title
     | #{campaign.name}
 
 block content
-    .admin-actions(style="margin-bottom: 1rem;")
+    .admin-actions
         a.btn-outline(href="/admin/campaigns") &larr; All Campaigns
-        a.btn-outline(href=`/admin/campaigns/${campaign.id}/edit` style="margin-left: 0.5rem;") Edit
+        a.btn-outline(href=`/admin/campaigns/${campaign.id}/edit`) Edit
         if !campaign.is_active
-            span.badge.badge-expired(style="margin-left: 0.5rem;") Inactive — no longer attributing
+            span.badge.badge-expired Inactive — no longer attributing
 
-    h2 Trackable Link
-    .form-group
-        input#campaign-url(type="text" value=url readonly style="font-family: monospace;")
-        .form-actions(style="margin-top: 0.5rem;")
-            button#copy-url.btn-outline(type="button" data-copy="#campaign-url") Copy link
-            a.btn-outline(href=url target="_blank" rel="noopener" style="margin-left: 0.5rem;") Open
+    .admin-panel
+        h3 Trackable Link
+        .form-group
+            input#campaign-url.input-mono(type="text" value=url readonly)
+            .form-actions.form-actions--tight
+                button#copy-url.btn-outline(type="button" data-copy="#campaign-url") Copy link
+                a.btn-outline(href=url target="_blank" rel="noopener") Open
 
-    h2(style="margin-top: 1.5rem;") QR Code
-    .qr-block(style="display:flex; gap:1.5rem; align-items:flex-start; flex-wrap:wrap;")
-        img#campaign-qr(src=`/admin/campaigns/${campaign.id}/qr.png?size=300` alt=`QR code for ${campaign.name}` width="300" height="300" style="border:1px solid #ddd; background:#fff;")
-        div
-            p.text-muted
-                | Scanning this code opens the link above, so every scan is counted as a visit.
-            p
-                a.btn(href=`/admin/campaigns/${campaign.id}/qr.png?size=1200&download=1`) Download PNG
-            p
-                a.btn-outline(href=`/admin/campaigns/${campaign.id}/qr.svg`) Download SVG
-            p.text-muted
-                | Use the SVG for anything printed larger than about two inches — it stays sharp at
-                | any size. The PNG is easier to drop into a Facebook post or an email.
+    .admin-panel
+        h3 QR Code
+        .qr-block
+            img#campaign-qr.qr-image(src=`/admin/campaigns/${campaign.id}/qr.png?size=300` alt=`QR code for ${campaign.name}` width="300" height="300")
+            div
+                p.text-muted
+                    | Scanning this code opens the link above, so every scan is counted as a visit.
+                p
+                    a.btn(href=`/admin/campaigns/${campaign.id}/qr.png?size=1200&download=1`) Download PNG
+                p
+                    a.btn-outline(href=`/admin/campaigns/${campaign.id}/qr.svg`) Download SVG
+                p.text-muted
+                    | Use the SVG for anything printed larger than about two inches — it stays sharp at
+                    | any size. The PNG is easier to drop into a Facebook post or an email.
 
-    h2(style="margin-top: 1.5rem;") Performance
-    table#campaign-stats.admin-table
-        tbody
-            tr
-                th(style="width: 14rem;") Visits
-                td#stat-visits= stats.visit_count
-            tr
-                th Membership signups
-                td#stat-signups= stats.signup_count
-            tr
-                th Contact submissions
-                td#stat-contacts= stats.contact_count
-            tr
-                th Conversion (signups / visits)
-                td= conversion
-
-    h2(style="margin-top: 1.5rem;") Attributed Signups
-    if signups.length === 0
-        p.text-muted No signups attributed to this campaign yet.
-    else
-        table#campaign-signups.admin-table
-            thead
-                tr
-                    th Member
-                    th Email
-                    th Status
-                    th Signed up
+    .admin-panel
+        h3 Performance
+        table#campaign-stats.admin-table.admin-table--kv
             tbody
-                each m in signups
-                    tr
-                        td: a(href=`/admin/members/${m.id}`)= `${m.first_name} ${m.last_name}`
-                        td= m.email
-                        td= m.status
-                        td= m.created_at
-
-    h2(style="margin-top: 1.5rem;") Contact Submissions
-    if submissions.length === 0
-        p.text-muted No contact submissions attributed to this campaign yet.
-    else
-        table#campaign-contacts.admin-table
-            thead
                 tr
-                    th Name
-                    th Email
-                    th Message
-                    th Received
-            tbody
-                each s in submissions
-                    tr
-                        td= s.name
-                        td= s.email
-                        td= s.message
-                        td= s.created_at
-
-    h2(style="margin-top: 1.5rem;") Recent Visits
-    if visits.length === 0
-        p.text-muted No visits recorded yet.
-    else
-        table#campaign-visits.admin-table
-            thead
+                    th Visits
+                    td#stat-visits= stats.visit_count
                 tr
-                    th Landed on
-                    th Referrer
-                    th Source / Medium
-                    th When
-            tbody
-                each v in visits
+                    th Membership signups
+                    td#stat-signups= stats.signup_count
+                tr
+                    th Contact submissions
+                    td#stat-contacts= stats.contact_count
+                tr
+                    th Conversion (signups / visits)
+                    td= conversion
+
+    .admin-panel
+        h3 Attributed Signups
+        if signups.length === 0
+            p.text-muted No signups attributed to this campaign yet.
+        else
+            table#campaign-signups.admin-table
+                thead
                     tr
-                        td= v.landing_path
-                        td.text-muted= v.referrer || 'direct'
-                        td.text-muted= [v.utm_source, v.utm_medium].filter(Boolean).join(' / ') || '—'
-                        td= v.created_at
-        p.text-muted Showing the 25 most recent. Visits are pruned after two years.
+                        th Member
+                        th Email
+                        th Status
+                        th Signed up
+                tbody
+                    each m in signups
+                        tr
+                            td: a(href=`/admin/members/${m.id}`)= `${m.first_name} ${m.last_name}`
+                            td= m.email
+                            td= m.status
+                            td= m.created_at
+
+    .admin-panel
+        h3 Contact Submissions
+        if submissions.length === 0
+            p.text-muted No contact submissions attributed to this campaign yet.
+        else
+            table#campaign-contacts.admin-table
+                thead
+                    tr
+                        th Name
+                        th Email
+                        th Message
+                        th Received
+                tbody
+                    each s in submissions
+                        tr
+                            td= s.name
+                            td= s.email
+                            td= s.message
+                            td= s.created_at
+
+    .admin-panel
+        h3 Recent Visits
+        if visits.length === 0
+            p.text-muted No visits recorded yet.
+        else
+            table#campaign-visits.admin-table
+                thead
+                    tr
+                        th Landed on
+                        th Referrer
+                        th Source / Medium
+                        th When
+                tbody
+                    each v in visits
+                        tr
+                            td= v.landing_path
+                            td.text-muted= v.referrer || 'direct'
+                            td.text-muted= [v.utm_source, v.utm_medium].filter(Boolean).join(' / ') || '—'
+                            td= v.created_at
+            p.text-muted Showing the 25 most recent. Visits are pruned after two years.
+

--- a/views/admin/campaigns/form.pug
+++ b/views/admin/campaigns/form.pug
@@ -22,7 +22,7 @@ block content
             input#target_path(type="text" name="target_path" value=(campaign ? campaign.target_path : defaultTargetPath) placeholder=defaultTargetPath)
             p.text-muted A path on this site, starting with "/". Use #{defaultTargetPath} to send people straight to the signup form.
 
-        h3(style="margin-top: 1.5rem;") Attribution Details
+        h3 Attribution Details
 
         .form-group
             label(for="utm_source") Source (utm_source)
@@ -45,4 +45,4 @@ block content
 
         .form-actions
             button.btn(type="submit")= campaign ? 'Save Changes' : 'Create Campaign'
-            a.btn-outline(href=(campaign ? `/admin/campaigns/${campaign.id}` : '/admin/campaigns') style="margin-left: 1rem;") Cancel
+            a.btn-outline(href=(campaign ? `/admin/campaigns/${campaign.id}` : '/admin/campaigns')) Cancel

--- a/views/admin/campaigns/list.pug
+++ b/views/admin/campaigns/list.pug
@@ -4,48 +4,46 @@ block page_title
     | Campaigns
 
 block content
-    .admin-actions(style="margin-bottom: 1rem;")
+    .admin-actions
         a.btn(href="/admin/campaigns/new") + New Campaign
-        a.btn-outline(href="/admin/campaigns.csv" style="margin-left: 0.5rem;") Export .csv
+        a.btn-outline(href="/admin/campaigns.csv") Export .csv
 
-    if campaigns.length === 0
-        p.text-muted
-            | No campaigns yet. Create one to get a trackable link and QR code for a flyer,
-            | a Facebook post, or the Council newsletter.
-    else
-        table#campaigns-table.admin-table
-            thead
-                tr
-                    th Name
-                    th Code
-                    th Source / Medium
-                    th Visits
-                    th Signups
-                    th Contacts
-                    th Conversion
-                    th Status
-                    th
-            tbody
-                each c in campaigns
+    .admin-panel
+        if campaigns.length === 0
+            p.text-muted
+                | No campaigns yet. Create one to get a trackable link and QR code for a flyer,
+                | a Facebook post, or the Council newsletter.
+        else
+            table#campaigns-table.admin-table
+                thead
                     tr
-                        td: a(href=`/admin/campaigns/${c.id}`)= c.name
-                        td: code= c.utm_campaign
-                        td.text-muted= [c.utm_source, c.utm_medium].filter(Boolean).join(' / ') || '—'
-                        td= c.visit_count
-                        td= c.signup_count
-                        td= c.contact_count
-                        td= conversionRate(c)
-                        td
-                            if c.is_active
-                                span.badge.badge-active Active
-                            else
-                                span.badge.badge-expired Inactive
-                        td
-                            a.btn-sm(href=`/admin/campaigns/${c.id}/edit`) Edit
-                            form(method="POST" action=`/admin/campaigns/${c.id}/toggle` style="display:inline" data-confirm=(c.is_active ? 'Deactivate this campaign? Links already in print will stop being attributed.' : 'Reactivate this campaign?'))
-                                button(type="submit" class=c.is_active ? 'btn-sm btn-danger' : 'btn-sm')= c.is_active ? 'Deactivate' : 'Reactivate'
+                        th Name
+                        th Code
+                        th Source / Medium
+                        th Visits
+                        th Signups
+                        th Contacts
+                        th Conversion
+                        th Status
+                        th
+                tbody
+                    each c in campaigns
+                        tr
+                            td: a(href=`/admin/campaigns/${c.id}`)= c.name
+                            td: code= c.utm_campaign
+                            td.text-muted= [c.utm_source, c.utm_medium].filter(Boolean).join(' / ') || '—'
+                            td= c.visit_count
+                            td= c.signup_count
+                            td= c.contact_count
+                            td= conversionRate(c)
+                            td
+                                +badge(c.is_active ? 'active' : 'expired', c.is_active ? 'Active' : 'Inactive')
+                            td
+                                .row-actions
+                                    a.btn-sm(href=`/admin/campaigns/${c.id}/edit`) Edit
+                                    +confirmForm(`/admin/campaigns/${c.id}/toggle`, c.is_active ? 'Deactivate this campaign? Links already in print will stop being attributed.' : 'Reactivate this campaign?', c.is_active ? 'Deactivate' : 'Reactivate', c.is_active)
 
-    p.text-muted(style="margin-top: 1.5rem;")
+    p.text-muted.page-footnote
         | Visits count one per visitor per campaign, exclude known bots, and are pruned after two
         | years. Signups and contact submissions are attributed on a first-touch basis — whichever
         | campaign brought someone here first keeps the credit.

--- a/views/admin/contact-submissions.pug
+++ b/views/admin/contact-submissions.pug
@@ -38,10 +38,4 @@ block content
                             else
                                 span.badge.badge-active Sent
 
-        if totalPages > 1
-            .pagination(style="margin-top: 1rem;")
-                if page > 1
-                    a.btn-outline(href=`/admin/contact-submissions?page=${page - 1}`) &larr; Previous
-                span.text-muted(style="margin: 0 0.75rem;")= `Page ${page} of ${totalPages} (${total} total)`
-                if page < totalPages
-                    a.btn-outline(href=`/admin/contact-submissions?page=${page + 1}`) Next &rarr;
+        +pagination(page, totalPages, total, (n) => `/admin/contact-submissions?page=${n}`)

--- a/views/admin/dashboard.pug
+++ b/views/admin/dashboard.pug
@@ -4,6 +4,9 @@ block page_title
   | Dashboard
 
 block content
+  //- One row of KPIs. The revenue figure is formatted short and .stat-number scales with
+  //- the card (see admin.css) so a long value cannot paint outside its card the way
+  //- "$2034.00" at a fixed 2.25rem did.
   .stats-grid
     a.stat-card(href="/admin/members")
       .stat-number= stats.totalMembers
@@ -22,9 +25,9 @@ block content
         .stat-number= stats.currentPeriodEnrollment
         .stat-label= `Enrolled ${stats.currentPeriodLabel}`
     a.stat-card(href="/admin/payments")
-      .stat-number $#{(stats.totalRevenue / 100).toFixed(2)}
+      .stat-number= formatMoneyShort(stats.totalRevenue)
       .stat-label Total Revenue
-    .stat-card
+    a.stat-card(href="/admin/emails")
       .stat-number= stats.emailsSent
       .stat-label Emails Sent
 
@@ -49,7 +52,7 @@ block content
                 td= formatDate(m.created_at)
       else
         p.text-muted No members yet.
-      p(style="margin-top: 1rem;"): a(href="/admin/members") View all members &rarr;
+      p.mt-md: a(href="/admin/members") View all members &rarr;
 
     .admin-panel
       h3 Recent Payments
@@ -64,11 +67,15 @@ block content
           tbody
             each p in recentPayments
               tr
-                td= p.first_name ? `${p.first_name} ${p.last_name}` : 'N/A'
-                td $#{(p.amount_cents / 100).toFixed(2)}
+                td
+                  if p.member_id && p.first_name
+                    a(href=`/admin/members/${p.member_id}`)= `${p.first_name} ${p.last_name}`
+                  else
+                    | N/A
+                td= formatMoney(p.amount_cents)
                 td
                   span(class=`badge badge-${p.status}`)= p.status
                 td= formatDate(p.created_at)
       else
         p.text-muted No payments yet.
-      p(style="margin-top: 1rem;"): a(href="/admin/payments") View all payments &rarr;
+      p.mt-md: a(href="/admin/payments") View all payments &rarr;

--- a/views/admin/emails/log.pug
+++ b/views/admin/emails/log.pug
@@ -4,9 +4,6 @@ block page_title
   | Email Log
 
 block content
-  .admin-toolbar
-    a.btn-outline(href="/admin/emails/renewal") Renewal Reminders
-
   if emails.length
     table.admin-table
       thead
@@ -25,12 +22,6 @@ block content
             td= e.status
             td= formatDate(e.created_at)
 
-    if totalPages > 1
-      .pagination
-        if page > 1
-          a(href=`/admin/emails?page=${page - 1}`) &laquo; Prev
-        span Page #{page} of #{totalPages} (#{total} total)
-        if page < totalPages
-          a(href=`/admin/emails?page=${page + 1}`) Next &raquo;
+    +pagination(page, totalPages, total, (n) => `/admin/emails?page=${n}`)
   else
     p.text-muted No emails sent yet.

--- a/views/admin/emails/renewal.pug
+++ b/views/admin/emails/renewal.pug
@@ -8,7 +8,7 @@ block content
         a.btn-outline(href="/admin/emails") Back to Email Log
 
     h3 Current Settings
-    table.admin-table(style="margin-bottom:2rem;")
+    table.admin-table.admin-table--kv.mb-lg
         tbody
             tr
                 td
@@ -34,7 +34,7 @@ block content
     else
         p.text-muted No members currently need renewal reminders. Members are eligible when they have an expiry date set within #{daysBefore} days and haven't renewed for the current year.
 
-    hr(style="margin:2rem 0;")
+    hr.rule-lg
     p.text-muted
         | Season dates are managed in
         a(href="/admin/periods")  Membership Periods

--- a/views/admin/gallery/form.pug
+++ b/views/admin/gallery/form.pug
@@ -12,9 +12,7 @@ block content
       label(for="image") Image File#{image ? '' : ' *'}
       input#image(type="file" name="image" accept="image/*")
       if image && image.filename
-        .image-preview
-          img(src=image.filename alt="Current image" style="max-height:120px; margin-top:0.5rem")
-          input(type="hidden" name="existing_image" value=image.filename)
+        +imagePreview(image.filename, 'existing_image', 'Current image')
     .form-group
       label(for="alt_text") Alt Text
       input#alt_text(type="text" name="alt_text" value=(image ? image.alt_text : ''))

--- a/views/admin/gallery/list.pug
+++ b/views/admin/gallery/list.pug
@@ -11,13 +11,11 @@ block content
     .gallery-admin-grid
       each img in images
         .gallery-admin-card
-          img(src=img.filename alt=img.alt_text || 'Gallery image' style="width:100%; height:150px; object-fit:cover; border-radius:4px")
+          img.gallery-admin-thumb(src=img.filename alt=img.alt_text || 'Gallery image')
           .gallery-admin-info
             p= img.alt_text || 'No alt text'
             span.text-muted Order: #{img.sort_order} | #{img.is_visible ? 'Visible' : 'Hidden'}
           .gallery-admin-actions
-            a.btn-sm(href=`/admin/gallery/${img.id}`) Edit
-            form(method="POST" action=`/admin/gallery/${img.id}/delete` style="display:inline" data-confirm="Delete this image?")
-              button.btn-sm.btn-danger(type="submit") Delete
+            +rowActions(`/admin/gallery/${img.id}`, `/admin/gallery/${img.id}/delete`, 'Delete this image?')
   else
     p.text-muted No gallery images yet.

--- a/views/admin/layout.pug
+++ b/views/admin/layout.pug
@@ -1,3 +1,5 @@
+include mixins
+
 doctype html
 html(lang="en")
   head
@@ -12,7 +14,7 @@ html(lang="en")
       aside.admin-sidebar
         .sidebar-brand
           a(href="/admin/dashboard")
-            img(src="/img/logo.png" alt="YSH" style="height:40px")
+            img.sidebar-logo(src="/img/logo.png" alt="YSH")
             span YSH Admin
         nav.sidebar-nav
           a(href="/admin/dashboard" class=(currentPath === '/admin/dashboard' ? 'active' : '')) Dashboard
@@ -32,7 +34,7 @@ html(lang="en")
             a(href="/admin/audit" class=(currentPath && currentPath.startsWith('/admin/audit') ? 'active' : '')) Audit Log
           hr
           a(href="/") View Site
-          form(method="POST" action="/admin/logout" style="display:inline")
+          form.inline-form(method="POST" action="/admin/logout")
             button.sidebar-logout(type="submit") Logout
 
       main.admin-main

--- a/views/admin/login-verify.pug
+++ b/views/admin/login-verify.pug
@@ -8,7 +8,7 @@ html(lang="en")
     link(rel="stylesheet" href="/css/admin.css")
   body.admin-login-body
     .admin-login-card
-      img(src="/img/YSH_Logo_Color_Transparent.png" alt="YSH" style="height:60px; margin-bottom:1rem")
+      img.login-logo(src="/img/YSH_Logo_Color_Transparent.png" alt="YSH")
       h2 Enter Login Code
       p.text-muted If this address is an admin, a verification code was sent to #{maskedEmail}
       if flash_success
@@ -19,10 +19,10 @@ html(lang="en")
         input(type="hidden" name="_csrf" value=csrfToken)
         .form-group
           label(for="code") 6-Digit Code
-          input#code(type="text" name="code" required autofocus maxlength="6" pattern="[0-9]{6}" inputmode="numeric" autocomplete="one-time-code" placeholder="000000" style="text-align:center; font-size:1.5rem; letter-spacing:0.5rem")
-        button.btn(type="submit" style="width:100%") Verify
-      .text-center(style="margin-top:1rem")
-        form(method="POST" action="/admin/login/resend" style="display:inline")
+          input#code.input-otp(type="text" name="code" required autofocus maxlength="6" pattern="[0-9]{6}" inputmode="numeric" autocomplete="one-time-code" placeholder="000000")
+        button.btn.btn-block(type="submit") Verify
+      .text-center.mt-md
+        form.inline-form(method="POST" action="/admin/login/resend")
           input(type="hidden" name="_csrf" value=csrfToken)
           button.btn-link(type="submit") Resend code
         span  |

--- a/views/admin/login.pug
+++ b/views/admin/login.pug
@@ -8,7 +8,7 @@ html(lang="en")
     link(rel="stylesheet" href="/css/admin.css")
   body.admin-login-body
     .admin-login-card
-      img(src="/img/YSH_Logo_Color_Transparent.png" alt="YSH" style="height:60px; margin-bottom:1rem")
+      img.login-logo(src="/img/YSH_Logo_Color_Transparent.png" alt="YSH")
       h2 Admin Login
       if flash_success
         .flash.flash-success= flash_success
@@ -19,4 +19,4 @@ html(lang="en")
         .form-group
           label(for="email") Email
           input#email(type="email" name="email" required autofocus placeholder="admin@example.com")
-        button.btn(type="submit" style="width:100%") Send Login Code
+        button.btn.btn-block(type="submit") Send Login Code

--- a/views/admin/members/form.pug
+++ b/views/admin/members/form.pug
@@ -11,11 +11,11 @@ block content
     if !member
       .form-group
         label Membership Type
-        .radio-group(style="margin-bottom: 1rem;")
-          label(style="display: inline-block; margin-right: 2rem;")
+        .radio-group
+          label
             input(type="radio" name="membership_type" value="individual" checked)
             |  Individual
-          label(style="display: inline-block;")
+          label
             input(type="radio" name="membership_type" value="family")
             |  Family
 
@@ -67,7 +67,7 @@ block content
       textarea#notes(name="notes" rows="3")= member ? member.notes : ''
 
     if !member
-      #family-members-section(style="display: none; margin-top: 2rem;")
+      #family-members-section.member-family-section(hidden)
         h3 Additional Family Members
         p.text-muted Add family members (optional). Each will receive their own member number and card.
 

--- a/views/admin/members/list.pug
+++ b/views/admin/members/list.pug
@@ -84,13 +84,7 @@ block content
             td
               a.btn-sm(href=`/admin/members/${m.id}`) Edit
 
-    if totalPages > 1
-      .pagination
-        if page > 1
-          a(href=`/admin/members${qs({page: page - 1})}`) &laquo; Prev
-        span Page #{page} of #{totalPages} (#{total} total)
-        if page < totalPages
-          a(href=`/admin/members${qs({page: page + 1})}`) Next &raquo;
+    +pagination(page, totalPages, total, (n) => `/admin/members${qs({page: n})}`)
   else
     if view === 'needs-attention' && !search && !status && !periodId && !signal
       p.text-muted No members need attention right now.

--- a/views/admin/members/view.pug
+++ b/views/admin/members/view.pug
@@ -4,234 +4,263 @@ block page_title
   | #{member.first_name} #{member.last_name}
 
 block content
-  .admin-grid
+  //- Actions are grouped primary / secondary / destructive in a bar of their own. They
+  //- used to sit in a .form-actions at the foot of the details table, each wrapped in
+  //- style="display:inline" — which kept every button out of the flex line and produced
+  //- two ragged rows. Labels are unchanged; robot selects Delete and Generate Renewal
+  //- Link by class and by text.
+  .record-actionbar
+    .actionbar-group
+      a.btn.btn-compact(href=`/admin/members/${member.id}?edit=1`) Edit
+    .actionbar-sep
+    .actionbar-group
+      form(method="POST" action=`/admin/members/${member.id}/card` data-spinner="Generating…")
+        button.btn-outline.btn-compact(type="submit") Generate Card
+      if !member.primary_member_id
+        form(method="POST" action=`/admin/members/${member.id}/renewal-link` data-spinner="Generating…")
+          button.btn-outline.btn-compact(type="submit") Generate Renewal Link
+      if member.membership_type !== 'family' && !member.primary_member_id
+        form(method="POST" action=`/admin/members/${member.id}/upgrade-to-family` data-confirm=`Upgrade ${member.first_name} ${member.last_name} to a family membership?`)
+          button.btn-outline.btn-compact(type="submit") Upgrade to Family
+    .actionbar-group.actionbar-danger
+      form(method="POST" action=`/admin/members/${member.id}/delete` data-confirm="Delete this member?")
+        button.btn-danger.btn-compact(type="submit") Delete
+
+  //- Full width and outside any disclosure: the URL is ~100 characters, and a robot test
+  //- reads this field's value straight after the redirect.
+  if flash_renewal_link
     .admin-panel
-      h3 Member Details
-      table.detail-table
-        tr
-          th Member Number
-          td= member.member_number
-        tr
-          th Name
-          td= `${member.first_name} ${member.last_name}`
-        tr
-          th Email
-          td= member.email
-        tr
-          th Phone
-          td= member.phone || '—'
-        tr
-          th Address
-          td= [member.address_street, member.address_city, member.address_state, member.address_zip].filter(Boolean).join(', ') || '—'
-        tr
-          th Year
-          td= member.membership_year
-        tr
-          th Join Date
-          td= formatDate(member.join_date)
-        tr
-          th Status
-          td
-            span(class=`badge badge-${member.status}`)= member.status
-            if member.is_lifetime
-              |
-              span.badge.badge-lifetime Lifetime
-        if member.membership_type
-          tr
-            th Membership Type
-            td= member.membership_type === 'family' ? 'Family' : 'Individual'
-        if member.primary_member_id && primaryMember
-          tr
-            th Primary Member
-            td
-              a(href=`/admin/members/${primaryMember.id}`) #{primaryMember.first_name} #{primaryMember.last_name} (#{primaryMember.member_number})
-        else if member.membership_type === 'family'
-          tr
-            th Family Members
-            td
-              if familyMembers.length
-                ul(style="margin: 0 0 0.5rem; padding-left: 1.5rem;")
-                  each fm in familyMembers
-                    li(style="margin-bottom: 0.25rem;")
-                      a(href=`/admin/members/${fm.id}`) #{fm.first_name} #{fm.last_name} (#{fm.member_number})
-                      |
-                      - const confirmMsg = fm.wouldDeleteOnRemove ? `${fm.first_name} ${fm.last_name} shares an email with an existing primary member — removing them will permanently delete their record. Continue?` : `Remove ${fm.first_name} ${fm.last_name} from this family membership?`
-                      form(method="POST" action=`/admin/members/${member.id}/family-members/${fm.id}/remove` style="display:inline" data-confirm=confirmMsg)
-                        button.btn-sm.btn-danger(type="submit" style="padding: 1px 8px; font-size: 0.75rem;")= fm.wouldDeleteOnRemove ? 'Remove (deletes record)' : 'Remove'
-              else
-                span.text-muted No family members yet.
-        tr
-          th Notes
-          td= member.notes || '—'
-        tr
-          th Created
-          td= formatDate(member.created_at)
-        tr
-          th Updated
-          td= formatDate(member.updated_at)
+      h3 Renewal Link
+      p.text-muted Read this out over the phone or paste it into a text. It goes straight to the renewal form — no email is sent.
+      .form-group
+        input#renewal-link.input-mono(type="text" value=flash_renewal_link.url readonly)
+        .form-actions.form-actions--tight
+          button#copy-renewal-link.btn-outline(type="button" data-copy="#renewal-link") Copy link
+          a.btn-outline(href=flash_renewal_link.url target="_blank" rel="noopener") Open
+        p.text-muted.mt-sm Expires #{formatDate(flash_renewal_link.expiresAt)}
 
-      .form-actions
-        a.btn(href=`/admin/members/${member.id}?edit=1`) Edit
-        form(method="POST" action=`/admin/members/${member.id}/card` style="display:inline" data-spinner="Generating…")
-          button.btn-outline(type="submit") Generate Card
-        if !member.primary_member_id
-          form(method="POST" action=`/admin/members/${member.id}/send-renewal` style="display:inline" data-confirm=`Send renewal reminder to ${member.first_name} ${member.last_name}?`)
-            button.btn-outline(type="submit") Send Renewal Reminder
-          form(method="POST" action=`/admin/members/${member.id}/renewal-link` style="display:inline" data-spinner="Generating…")
-            button.btn-outline(type="submit") Generate Renewal Link
-        if member.membership_type !== 'family' && !member.primary_member_id
-          form(method="POST" action=`/admin/members/${member.id}/upgrade-to-family` style="display:inline" data-confirm=`Upgrade ${member.first_name} ${member.last_name} to a family membership?`)
-            button.btn-outline(type="submit") Upgrade to Family
-        form(method="POST" action=`/admin/members/${member.id}/delete` style="display:inline" data-confirm="Delete this member?")
-          button.btn-danger(type="submit") Delete
-
-    if flash_renewal_link
+  //- Wide column for the record and its history tables; a narrow rail for the things
+  //- that are only a few words wide. The old .admin-grid (auto-fit minmax(400px, 1fr))
+  //- gave the near-empty Membership Cards panel half the viewport.
+  .record-layout
+    .record-main
       .admin-panel
-        h3 Renewal Link
-        p.text-muted Read this out over the phone or paste it into a text. It goes straight to the renewal form — no email is sent.
-        .form-group
-          input#renewal-link(type="text" value=flash_renewal_link.url readonly style="font-family: monospace;")
-          .form-actions(style="margin-top: 0.5rem;")
-            button#copy-renewal-link.btn-outline(type="button" data-copy="#renewal-link") Copy link
-            a.btn-outline(href=flash_renewal_link.url target="_blank" rel="noopener" style="margin-left: 0.5rem;") Open
-          p.text-muted(style="margin-top: 0.5rem;") Expires #{formatDate(flash_renewal_link.expiresAt)}
-
-    .admin-panel
-      h3 Membership Cards
-      if cards.length
-        each card in cards
-          .card-row
-            span Year: #{card.year}
-            if card.pdf_path
-              a.btn-sm(href=`/admin/members/${member.id}/card/pdf`) PDF
-            if card.png_path
-              a.btn-sm(href=`/admin/members/${member.id}/card/png`) PNG
-            form(method="POST" action=`/admin/members/${member.id}/email-card` style="display:inline")
-              button.btn-sm(type="submit") Email Card
-      else
-        p.text-muted No cards generated yet.
-
-  if member.membership_type !== 'family' && !member.primary_member_id && familyPrimaries.length
-    .admin-panel
-      h3 Attach to Family
-      form(method="POST" action=`/admin/members/${member.id}/attach-to-family`)
-        .form-group
-          label(for="primary_member_id") Family
-          select#primary_member_id.form-control(name="primary_member_id" required)
-            option(value="" disabled selected) — select a family —
-            each p in familyPrimaries
-              option(value=p.id) #{p.first_name} #{p.last_name} (#{p.member_number})
-        .form-actions
-          button.btn(type="submit") Attach to Family
-
-  if member.membership_type === 'family' && !member.primary_member_id
-    .admin-panel
-      h3 Add Family Member
-      form(method="POST" action=`/admin/members/${member.id}/family-members`)
-        .form-group
-          label(for="fm_first_name") First Name
-          input#fm_first_name.form-control(type="text" name="first_name" required)
-        .form-group
-          label(for="fm_last_name") Last Name
-          input#fm_last_name.form-control(type="text" name="last_name" required)
-        .form-group
-          label(for="fm_email") Email (optional)
-          input#fm_email.form-control(type="email" name="email" placeholder=`Defaults to ${member.email}`)
-        .form-actions
-          button.btn(type="submit") Add Family Member
-
-  .admin-panel
-    h3 Payments
-    if payments.length
-      table.admin-table
-        thead
+        h3 Member Details
+        table.detail-table
           tr
-            th Amount
-            th Status
-            th Method
-            th Description
-            th Date
-        tbody
-          each p in payments
-            tr
-              td $#{(p.amount_cents / 100).toFixed(2)}
-              td
-                span(class=`badge badge-${p.status}`)= p.status
-              td= p.payment_method || 'stripe'
-              td= p.description || '—'
-              td= formatDate(p.created_at)
-    else
-      p.text-muted No payments yet.
-
-  .admin-panel
-    h3 Membership Years
-    if membershipYears.length
-      table.admin-table
-        thead
+            th Member Number
+            td= member.member_number
           tr
-            th Period
-            th Enrolled
-            th Payment
-            th Status
-        tbody
-          each my in membershipYears
+            th Name
+            td= `${member.first_name} ${member.last_name}`
+          tr
+            th Email
+            td= member.email
+          tr
+            th Phone
+            td= member.phone || '—'
+          tr
+            th Address
+            td= [member.address_street, member.address_city, member.address_state, member.address_zip].filter(Boolean).join(', ') || '—'
+          tr
+            th Notes
+            td= member.notes || '—'
+          if member.primary_member_id && primaryMember
             tr
-              td= my.label
-              td= formatDate(my.created_at)
+              th Primary Member
               td
-                if my.payment_id
-                  | $#{(my.amount_cents / 100).toFixed(2)} via #{my.payment_method || 'stripe'} on #{formatDate(my.payment_date)}
+                a(href=`/admin/members/${primaryMember.id}`) #{primaryMember.first_name} #{primaryMember.last_name} (#{primaryMember.member_number})
+          else if member.membership_type === 'family'
+            tr
+              th Family Members
+              td
+                if familyMembers.length
+                  ul.family-member-list
+                    each fm in familyMembers
+                      li
+                        a(href=`/admin/members/${fm.id}`) #{fm.first_name} #{fm.last_name} (#{fm.member_number})
+                        |
+                        - const confirmMsg = fm.wouldDeleteOnRemove ? `${fm.first_name} ${fm.last_name} shares an email with an existing primary member — removing them will permanently delete their record. Continue?` : `Remove ${fm.first_name} ${fm.last_name} from this family membership?`
+                        form.inline-form(method="POST" action=`/admin/members/${member.id}/family-members/${fm.id}/remove` data-confirm=confirmMsg)
+                          button.btn-tiny.btn-danger(type="submit")= fm.wouldDeleteOnRemove ? 'Remove (deletes record)' : 'Remove'
                 else
-                  | —
-              td
-                if my.payment_id
-                  span(class=`badge badge-${my.payment_status}`)= my.payment_status
-                else
-                  | —
-    else
-      p.text-muted No enrollment history.
+                  span.text-muted No family members yet.
 
-  .admin-panel
-    h3 Record Offline Payment
-    form(method="POST" action=`/admin/members/${member.id}/payments`)
-      .form-group
-        label(for="amount") Amount ($)
-        input#amount.form-control(type="number" name="amount" step="0.01" min="0.01" required)
-      .form-group
-        label(for="payment_method") Payment Method
-        select#payment_method.form-control(name="payment_method")
-          option(value="cash") Cash
-          option(value="check") Check
-          option(value="other") Other
-      .form-group
-        label(for="description") Description
-        input#description.form-control(type="text" name="description" placeholder="Membership dues")
-      .form-group
-        label
-          if member.status !== 'active'
-            input(type="checkbox" name="activate_member" checked)
-          else
-            input(type="checkbox" name="activate_member")
-          |  Activate member
-      .form-actions
-        button.btn(type="submit") Record Payment
+        if member.membership_type !== 'family' && !member.primary_member_id && familyPrimaries.length
+          details.disclosure(open=(flash_reopen === 'attach-family'))
+            summary Attach to Family
+            .disclosure-body
+              form#attach-family(method="POST" action=`/admin/members/${member.id}/attach-to-family`)
+                .form-group
+                  label(for="primary_member_id") Family
+                  select#primary_member_id.form-control(name="primary_member_id" required)
+                    option(value="" disabled selected) — select a family —
+                    each p in familyPrimaries
+                      option(value=p.id) #{p.first_name} #{p.last_name} (#{p.member_number})
+                .form-actions
+                  button.btn(type="submit") Attach to Family
 
-  .admin-panel
-    h3 Recent Emails
-    if emails.length
-      table.admin-table
-        thead
+        if member.membership_type === 'family' && !member.primary_member_id
+          details.disclosure(open=(flash_reopen === 'add-family-member'))
+            summary Add Family Member
+            .disclosure-body
+              form#add-family-member(method="POST" action=`/admin/members/${member.id}/family-members`)
+                .form-group
+                  label(for="fm_first_name") First Name
+                  input#fm_first_name.form-control(type="text" name="first_name" required)
+                .form-group
+                  label(for="fm_last_name") Last Name
+                  input#fm_last_name.form-control(type="text" name="last_name" required)
+                .form-group
+                  label(for="fm_email") Email (optional)
+                  input#fm_email.form-control(type="email" name="email" placeholder=`Defaults to ${member.email}`)
+                .form-actions
+                  button.btn(type="submit") Add Family Member
+
+      .admin-panel
+        h3 Payments
+        if payments.length
+          table#member-payments.admin-table
+            thead
+              tr
+                th Amount
+                th Status
+                th Method
+                th Description
+                th Date
+            tbody
+              each p in payments
+                tr
+                  td= formatMoney(p.amount_cents)
+                  td
+                    +badge(p.status, p.status)
+                  td= p.payment_method || 'stripe'
+                  td= p.description || '—'
+                  td= formatDate(p.created_at)
+        else
+          p.text-muted No payments yet.
+
+        details.disclosure(open=(flash_reopen === 'record-payment'))
+          summary Record Offline Payment
+          .disclosure-body
+            form#record-payment(method="POST" action=`/admin/members/${member.id}/payments`)
+              .form-group
+                label(for="amount") Amount ($)
+                input#amount.form-control(type="number" name="amount" step="0.01" min="0.01" required value=defaultPaymentDollars)
+                if currentPeriod && defaultPaymentDollars
+                  small.form-hint Default #{member.membership_type === 'family' ? 'family' : 'individual'} dues for #{currentPeriod.label}.
+              .form-group
+                label(for="payment_method") Payment Method
+                select#payment_method.form-control(name="payment_method")
+                  option(value="cash") Cash
+                  option(value="check") Check
+                  option(value="other") Other
+              .form-group
+                label(for="description") Description
+                input#description.form-control(type="text" name="description" placeholder="Membership dues")
+              .form-group
+                label.checkbox-label
+                  if member.status !== 'active'
+                    input(type="checkbox" name="activate_member" checked)
+                  else
+                    input(type="checkbox" name="activate_member")
+                  |  Activate member
+              .form-actions
+                button.btn(type="submit") Record Payment
+
+      .admin-panel
+        h3 Membership Years
+        if membershipYears.length
+          table.admin-table
+            thead
+              tr
+                th Period
+                th Enrolled
+                th Payment
+                th Status
+            tbody
+              each my in membershipYears
+                tr
+                  td= my.label
+                  td= formatDate(my.created_at)
+                  td
+                    if my.payment_id
+                      | #{formatMoney(my.amount_cents)} via #{my.payment_method || 'stripe'} on #{formatDate(my.payment_date)}
+                    else
+                      | —
+                  td
+                    if my.payment_id
+                      +badge(my.payment_status, my.payment_status)
+                    else
+                      | —
+        else
+          p.text-muted No enrollment history.
+
+      .admin-panel
+        h3 Recent Emails
+        if emails.length
+          table.admin-table
+            thead
+              tr
+                th Subject
+                th Type
+                th Status
+                th Date
+            tbody
+              each e in emails
+                tr
+                  td= e.subject
+                  td= e.email_type
+                  td= e.status
+                  td= formatDate(e.created_at)
+        else
+          p.text-muted No emails sent yet.
+
+    aside.record-rail
+      .admin-panel
+        h3 Snapshot
+        //- Deliberately not .detail-table: robot's Get Text runs in strict mode, so a
+        //- second element matching that selector would break View Member Details.
+        table.snapshot-table
           tr
-            th Subject
-            th Type
             th Status
-            th Date
-        tbody
-          each e in emails
+            td
+              +badge(member.status, member.status)
+              if member.is_lifetime
+                |
+                span.badge.badge-lifetime Lifetime
+          if member.membership_type
             tr
-              td= e.subject
-              td= e.email_type
-              td= e.status
-              td= formatDate(e.created_at)
-    else
-      p.text-muted No emails sent yet.
+              th Type
+              td= member.membership_type === 'family' ? 'Family' : 'Individual'
+          tr
+            th Year
+            td= member.membership_year
+          tr
+            th Joined
+            td= formatDate(member.join_date)
+          tr
+            th Created
+            td= formatDate(member.created_at)
+          tr
+            th Updated
+            td= formatDate(member.updated_at)
+
+      .admin-panel
+        h3 Membership Cards
+        if cards.length
+          each card in cards
+            //- Year on its own line, actions on the next. Side by side in the 320px rail
+            //- both the label and "Email Card" wrapped to two lines, which left the three
+            //- buttons at different heights.
+            .card-row
+              .card-row-year Year #{card.year}
+              .card-row-actions
+                if card.pdf_path
+                  a.btn-sm(href=`/admin/members/${member.id}/card/pdf`) PDF
+                if card.png_path
+                  a.btn-sm(href=`/admin/members/${member.id}/card/png`) PNG
+                form.inline-form(method="POST" action=`/admin/members/${member.id}/email-card`)
+                  button.btn-sm(type="submit") Email
+        else
+          p.text-muted No cards generated yet.

--- a/views/admin/mixins.pug
+++ b/views/admin/mixins.pug
@@ -1,0 +1,68 @@
+//- Shared admin markup components.
+//-
+//- Included once from views/admin/layout.pug. Pug makes mixins declared in a file that
+//- the layout includes visible inside every extending template's `block content`, so no
+//- page needs its own include.
+//-
+//- Each mixin here replaced several hand-rolled copies of the same markup that had
+//- drifted apart — different button classes, different pagination glyphs, four separate
+//- ways of turning a status into a badge. Prefer extending a mixin over reintroducing a
+//- local variant.
+//-
+//- No mixin emits a hidden _csrf input: public/js/admin.js injects one into every POST
+//- form that lacks it.
+
+//- A POST action that needs confirming, rendered as a single button.
+//- `data-confirm` is read by public/js/admin.js — inline onclick cannot be used here
+//- because helmet sends script-src-attr 'none'.
+mixin confirmForm(action, confirmText, label, danger)
+  form.inline-form(method="POST" action=action data-confirm=confirmText)
+    button(type="submit" class=danger ? 'btn-sm btn-danger' : 'btn-sm')= label
+
+//- The Edit + Delete cell that ends most admin list rows.
+mixin rowActions(editHref, deleteAction, confirmText, deleteLabel)
+  .row-actions
+    a.btn-sm(href=editHref) Edit
+    +confirmForm(deleteAction, confirmText, deleteLabel || 'Delete', true)
+
+//- Pager shared by the members, emails, audit and contact-submission lists.
+//- hrefFor is a function of the target page number, so each caller keeps its own query
+//- string handling (members/list.pug passes its qs() helper straight through).
+mixin pagination(page, totalPages, total, hrefFor)
+  if totalPages > 1
+    .pagination
+      if page > 1
+        a(href=hrefFor(page - 1)) &laquo; Prev
+      span
+        | Page #{page} of #{totalPages}
+        if total !== undefined && total !== null
+          |  (#{total} total)
+      if page < totalPages
+        a(href=hrefFor(page + 1)) Next &raquo;
+
+//- Existing-image thumbnail plus the hidden field that preserves it across a submit.
+mixin imagePreview(src, fieldName, alt, round)
+  .image-preview(class=round ? 'image-preview--round' : null)
+    img(src=src alt=alt || 'Current image')
+    input(type="hidden" name=fieldName value=src)
+
+//- Submit + Cancel footer. .form-actions already supplies the gap, so callers must not
+//- add margins to the cancel link.
+mixin formActions(submitLabel, cancelHref, cancelLabel)
+  .form-actions
+    button.btn(type="submit")= submitLabel
+    if cancelHref
+      a.btn-outline(href=cancelHref)= cancelLabel || 'Cancel'
+
+//- Status pill. `kind` is the badge-* suffix; the .badge-* scale lives in admin.css.
+mixin badge(kind, label)
+  span(class=`badge badge-${kind}`)= label
+
+//- Toolbar row: a primary "new" action and an optional CSV export.
+mixin toolbarActions(newHref, newLabel, exportHref, exportLabel)
+  .admin-toolbar
+    .toolbar-actions
+      if newHref
+        a.btn(href=newHref)= newLabel
+      if exportHref
+        a.btn-outline(href=exportHref)= exportLabel || 'Export CSV'

--- a/views/admin/payments.pug
+++ b/views/admin/payments.pug
@@ -21,9 +21,17 @@ block content
       tbody
         each p in payments
           tr
-            td= p.first_name ? `${p.first_name} ${p.last_name}` : 'N/A'
+            td
+              //- Guarded on both: member_id is NOT NULL in the schema, so the only case
+              //- the first_name check covers is a missing member row — exactly the case
+              //- an id-only link would 404 on. Only the name is linked; the number in the
+              //- next cell would be a second tab stop to the same place.
+              if p.member_id && p.first_name
+                a(href=`/admin/members/${p.member_id}`)= `${p.first_name} ${p.last_name}`
+              else
+                | N/A
             td= p.member_number || '—'
-            td $#{(p.amount_cents / 100).toFixed(2)}
+            td= formatMoney(p.amount_cents)
             td
               span(class=`badge badge-${p.status}`)= p.status
             td= p.payment_method || 'stripe'

--- a/views/admin/periods/form.pug
+++ b/views/admin/periods/form.pug
@@ -19,7 +19,7 @@ block content
             input#end_date(type="date" name="end_date" value=(period ? period.end_date : '') required)
             p.text-muted Date stamped on all members activated during this period. Typically July 31 of the following year.
 
-        h3(style="margin-top: 1.5rem;") Pricing
+        h3 Pricing
 
         .form-group
             label(for="individual_dues") Individual Dues
@@ -40,7 +40,7 @@ block content
                 input#electronic_surcharge(type="number" name="electronic_surcharge" step="0.01" min="0" value=(period ? centsToDollars(period.electronic_surcharge_cents) : '0.00') placeholder="1.50")
             p.text-muted Flat fee added to Stripe checkouts only. Cash/check payments are not affected.
 
-        h3(style="margin-top: 1.5rem;") Membership Card Template
+        h3 Membership Card Template
 
         .form-group
             label(for="image") Card Template (PNG or PDF)
@@ -50,7 +50,7 @@ block content
                 //- filename that lived in public/img/.
                 - const tpl = period.card_template_path
                 - const tplHref = /^(https?:\/\/|\/)/.test(tpl) ? tpl : `/img/${tpl}`
-                p.text-muted(style="margin-top: 0.5rem;")
+                p.text-muted.mt-sm
                     | Current: #{tpl} &mdash;
                     a(href=tplHref target="_blank") preview
             else
@@ -58,4 +58,4 @@ block content
 
         .form-actions
             button.btn(type="submit")= period ? 'Save Changes' : 'Create Period'
-            a.btn-outline(href="/admin/periods" style="margin-left: 1rem;") Cancel
+            a.btn-outline(href="/admin/periods") Cancel

--- a/views/admin/periods/list.pug
+++ b/views/admin/periods/list.pug
@@ -4,44 +4,45 @@ block page_title
     | Membership Periods
 
 block content
-    .admin-actions(style="margin-bottom: 1rem;")
+    .admin-actions
         a.btn(href="/admin/periods/new") + New Period
 
-    if periods.length === 0
-        p.text-muted No membership periods defined yet.
-    else
-        table.admin-table
-            thead
-                tr
-                    th Label
-                    th Start Date
-                    th End Date
-                    th Individual Dues
-                    th Family Dues
-                    th Surcharge
-                    th Status
-                    th
-            tbody
-                each period in periods
+    .admin-panel
+        if periods.length === 0
+            p.text-muted No membership periods defined yet.
+        else
+            table.admin-table
+                thead
                     tr
-                        td= period.label || '—'
-                        td= period.start_date
-                        td= period.end_date
-                        td= '$' + (period.individual_dues_cents / 100).toFixed(2)
-                        td= '$' + (period.family_dues_cents / 100).toFixed(2)
-                        td= '$' + (period.electronic_surcharge_cents / 100).toFixed(2)
-                        td
-                            if currentPeriod && currentPeriod.id === period.id
-                                span.badge.badge-active Current
-                            else if today > period.end_date
-                                span.badge.badge-expired Expired
-                            else if today < period.start_date
-                                span.badge Future
-                            else
-                                span.badge Inactive
-                        td
-                            a(href=`/admin/periods/${period.id}/edit`) Edit
+                        th Label
+                        th Start Date
+                        th End Date
+                        th Individual Dues
+                        th Family Dues
+                        th Surcharge
+                        th Status
+                        th
+                tbody
+                    each period in periods
+                        tr
+                            td= period.label || '—'
+                            td= period.start_date
+                            td= period.end_date
+                            td= '$' + (period.individual_dues_cents / 100).toFixed(2)
+                            td= '$' + (period.family_dues_cents / 100).toFixed(2)
+                            td= '$' + (period.electronic_surcharge_cents / 100).toFixed(2)
+                            td
+                                if currentPeriod && currentPeriod.id === period.id
+                                    span.badge.badge-active Current
+                                else if today > period.end_date
+                                    span.badge.badge-expired Expired
+                                else if today < period.start_date
+                                    span.badge Future
+                                else
+                                    span.badge Inactive
+                            td
+                                a(href=`/admin/periods/${period.id}/edit`) Edit
 
-    p.text-muted(style="margin-top: 1.5rem;")
+    p.text-muted.page-footnote
         | Periods become current automatically when today falls within their date range.
         | Overlapping seasons are allowed — the one with the latest start date is used for new signups.

--- a/views/admin/reports/membership.pug
+++ b/views/admin/reports/membership.pug
@@ -4,85 +4,103 @@ block page_title
     | Council Membership Report
 
 block content
-    p.text-muted
-        | Generates the Sea Hawkers Central Council "Chapter Membership Tracking Report"
-        | in the Council's own workbook format, ready to submit as-is.
-
-    form(method="GET" action="/admin/reports/membership" style="margin-bottom: 1.5rem;")
-        .form-group
-            label(for="period") Membership period
-            select#period(name="period" data-auto-submit)
-                each p in periods
-                    option(value=p.id selected=(period && period.id === p.id))= `${p.label || 'Period ' + p.id} (${p.start_date} → ${p.end_date})`
-            small.form-hint Everyone enrolled in this period is listed, family members included.
-        .form-actions
-            button#apply-period.btn-outline(type="submit") Apply period
+    //- The steps were already in the right order; they just did not look like a
+    //- sequence, because nothing had a container and everything floated on the page
+    //- background. Field widths are capped per-field (.form-group--narrow) rather than
+    //- by capping the page, which used to leave the period select a monitor wide.
+    .report-page
+        .admin-panel
+            h3 1. Choose the period
+            p.text-muted
+                | Generates the Sea Hawkers Central Council "Chapter Membership Tracking Report"
+                | in the Council's own workbook format, ready to submit as-is.
+            form(method="GET" action="/admin/reports/membership")
+                .form-group.form-group--narrow
+                    label(for="period") Membership period
+                    select#period(name="period" data-auto-submit)
+                        each p in periods
+                            option(value=p.id selected=(period && period.id === p.id))= `${p.label || 'Period ' + p.id} (${p.start_date} → ${p.end_date})`
+                //- Kept as the no-JS fallback: data-auto-submit is JavaScript, and this
+                //- path has silently died once already under script-src-attr 'none'.
+                .form-actions
+                    button#apply-period.btn-outline(type="submit") Apply period
 
     if !period
-        .flash.flash-error No membership periods are defined yet, so there is nothing to report.
+        .report-page
+            .flash.flash-error.report-notice No membership periods are defined yet, so there is nothing to report.
     else
         if warnings.length
-            .flash.flash-error
-                strong Before you submit:
-                ul(style="margin: 0.5rem 0 0 1.25rem;")
-                    each warning in warnings
-                        li= warning
+            .report-page
+                .flash.flash-error.report-notice.report-notice--caution
+                    strong.report-notice-title Before you submit
+                    ul.report-notice-list
+                        each warning in warnings
+                            li= warning
 
-        h2(style="margin-top: 1.5rem;") Preview
-        table#report-summary.admin-table
-            tbody
-                tr
-                    th(style="width: 14rem;") Total member count
-                    td= members.length
-                tr
-                    th Board members listed
-                    td= `${board.length} of ${boardCapacity}`
-                each link in social
-                    tr
-                        th= link[0]
-                        td: a(href=link[1] target="_blank" rel="noopener")= link[1]
+        .report-page
+            .admin-panel
+                h3 2. Review what gets submitted
+                //- Stays a <table> with this id because the tests locate it that way,
+                //- but it is a two-row summary rather than data — borderless, so it
+                //- reads as a pair of figures instead of competing with the real data
+                //- table directly below it.
+                table#report-summary.summary-table
+                    tbody
+                        tr
+                            th(scope="row") Total member count
+                            td= members.length
+                        tr
+                            th(scope="row") Board members listed
+                            td= `${board.length} of ${boardCapacity}`
 
-        h2(style="margin-top: 1.5rem;") Board block
-        p.text-muted Positions come from the Role on each visible board bio, in bio sort order.
-        table#report-board.admin-table
-            thead
-                tr
-                    th Position
-                    th Name
-                    th Email
-            tbody
-                if !board.length
-                    tr: td(colspan="3") No visible board bios.
-                each entry in board
-                    tr
-                        td
-                            if entry.position
-                                = entry.position
-                            else
-                                a(href=`/admin/bios/${entry.bioId}`) Add a role
-                        td= entry.name || '—'
-                        td
-                            if entry.email
-                                = entry.email
-                            else
-                                a(href=`/admin/bios/${entry.bioId}`) Add an email
+                h4.report-subhead Board block
+                p.text-muted Positions come from the Role on each visible board bio, in bio sort order.
+                table#report-board.admin-table
+                    thead
+                        tr
+                            th Position
+                            th Name
+                            th Email
+                    tbody
+                        if !board.length
+                            tr: td(colspan="3") No visible board bios.
+                        each entry in board
+                            tr
+                                td
+                                    if entry.position
+                                        = entry.position
+                                    else
+                                        a(href=`/admin/bios/${entry.bioId}`) Add a role
+                                td= entry.name || '—'
+                                td
+                                    if entry.email
+                                        = entry.email
+                                    else
+                                        a(href=`/admin/bios/${entry.bioId}`) Add an email
 
-        h2(style="margin-top: 1.5rem;") Download
-        form(method="GET" action="/admin/reports/membership/download")
-            input(type="hidden" name="period" value=period.id)
-            .form-grid
-                .form-group
-                    label(for="chapter_name") Chapter name
-                    input#chapter_name(type="text" name="chapter_name" value=chapterName)
-                .form-group
-                    label(for="month_year") Month/year ending
-                    input#month_year(type="text" name="month_year" value=monthYearEnding)
-            .form-group
-                label(for="submitted_by") Submitted by
-                input#submitted_by(type="text" name="submitted_by" value=submittedBy)
-            .form-group
-                label(for="filename") File name
-                input#filename(type="text" name="filename" value=reportFilename)
-                small.form-hint Prefilled with the standard name — edit it if the Council asked for something else.
-            .form-actions
-                button#download-report.btn(type="submit")= `Download .xlsx (${members.length} ${members.length === 1 ? 'member' : 'members'})`
+                h4.report-subhead Chapter links
+                dl.report-links
+                    each link in social
+                        div
+                            dt= link[0]
+                            dd: a(href=link[1] target="_blank" rel="noopener")= link[1]
+
+            .admin-panel
+                h3 3. Download
+                form(method="GET" action="/admin/reports/membership/download")
+                    input(type="hidden" name="period" value=period.id)
+                    .form-grid.form-grid--narrow
+                        .form-group
+                            label(for="chapter_name") Chapter name
+                            input#chapter_name(type="text" name="chapter_name" value=chapterName)
+                        .form-group
+                            label(for="month_year") Month/year ending
+                            input#month_year(type="text" name="month_year" value=monthYearEnding)
+                    .form-group.form-group--narrow
+                        label(for="submitted_by") Submitted by
+                        input#submitted_by(type="text" name="submitted_by" value=submittedBy)
+                    .form-group.form-group--narrow
+                        label(for="filename") File name
+                        input#filename(type="text" name="filename" value=reportFilename)
+                    .form-actions
+                        button#download-report.btn(type="submit")= `Download .xlsx (${members.length} ${members.length === 1 ? 'member' : 'members'})`


### PR DESCRIPTION
# Overview

Four reported defects, and the reason all four existed.

Dashboard KPI values painted outside their cards. Two causes: "$2034.00" is one unbreakable token, and .stats-grid's explicit minmax(180px, 1fr) floor suppressed the automatic min-content minimum so the track could not grow past its share, leaving ~124px of content inside 1.75rem of padding. Revenue now formats short ($2,034) and .stat-number scales to its card via container queries. A larger track floor alone only moves the width at which a long figure spills again.

The member record's buttons wrapped into two ragged rows because each POST form carried style="display:inline", which kept every button out of the flex line. They are now a grouped action bar (primary / secondary / destructive). The near empty Membership Cards panel no longer takes half the viewport: wide column for the record and its history tables, 320px rail for cards and a snapshot. 

Payments link back to the member, guarded on member_id AND first_name: member_id is NOT NULL, so the only case the existing first_name guard covers is a vanished member row, which is exactly what an id-only link would 404 on.

The council report is three numbered cards, its summary restyled as figures rather than a table whose columns could never line up with the board block beneath it, and its pre-flight warnings are an amber card instead of a full-bleed red band.

Underneath all of it there was no admin design system: .admin-actions was used by three templates and defined nowhere, ~74 inline style attributes carried layout across 21 templates, audit.pug embedded a 76-line stylesheet that leaked a global `details summary` rule, and 136 colour/radius/shadow literals were hardcoded. Those are now tokens, a shared mixin library, and real CSS rules; no inline styles remain in views/admin.

Four bugs surfaced on the way and are fixed here:

- .audit-badge and its --insert/--update/--delete modifiers were styled in neither stylesheet nor in audit.pug's own style block, so every audit action rendered as unstyled text.
- routes/admin.js computed currentPeriod and defaultPaymentDollars and the template referenced neither, so the offline-payment amount never prefilled. Guarded too: centsToDollars(undefined) returns the string "NaN".
- .btn-outline.btn-compact rendered 42px against 40px for its borderless siblings, leaving the action row a pixel out of alignment. min-height is only a floor and the 2px border pushed the content box past it.
- DatabaseManager.seed_member numbered members by a total COUNT(*) while services/members.generateMemberNumber counts within the year. The two drift apart as soon as any row has a different membership_year (the seeded admin does) and then collide on members.member_number the first time the app creates a member itself.

## Checklist
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] No `.env` or secrets committed
