### PR TITLE
lay admin tables out as cards on a phone

### DIFF
--- a/public/css/admin.css
+++ b/public/css/admin.css
@@ -858,6 +858,17 @@ a.stat-card:hover {
     align-items: stretch;
   }
 
+  /* .btn gets width: 100% below, .btn-outline deliberately does not — side by side in a flex
+     row that let "+ New Member" take the line and squeezed "Export CSV" onto two. */
+  .toolbar-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .toolbar-actions .btn-outline {
+    text-align: center;
+  }
+
   .search-form {
     width: 100%;
   }
@@ -865,6 +876,19 @@ a.stat-card:hover {
   .search-form input {
     flex: 1;
     font-size: 16px; /* Prevents iOS zoom on focus */
+  }
+
+  /* The 280px floor overflows a 320px viewport on its own, before any table does. A whole
+     line each also stops the search field sharing a row with the period select at a width
+     where neither is readable. */
+  .search-form-wide input[type="search"] {
+    min-width: 0;
+    max-width: none;
+    flex-basis: 100%;
+  }
+
+  .search-form-wide select {
+    flex: 1;
   }
 
   .admin-content .form-group input,
@@ -880,6 +904,12 @@ a.stat-card:hover {
   .admin-table th,
   .admin-table td {
     padding: 0.75rem;
+  }
+
+  /* Was 1.75rem all round, which left only ~286px of content inside a 390px viewport --
+     half the reason the payment table had nowhere to go but off the side of the page. */
+  .admin-panel {
+    padding: 1.25rem 1rem;
   }
 
   .btn,
@@ -1506,4 +1536,153 @@ a.stat-card:hover {
 
 .flash-list {
   margin: 0.5rem 0 0 1.25rem;
+}
+
+/* === Mobile table cards ===
+   Below 768px a 5-to-9 column table cannot fit, and nothing here gave it a scroll
+   container: .admin-content carries no overflow-x (deliberately, so desktop tables get the
+   full width) and .admin-main has min-width: 0, so the overflow landed on the *document*.
+   The page then scrolled sideways, which is what made the panels look off-centre with a
+   grey strip down the left — the cards were centred, the page was scrolled.
+
+   So each row becomes a card instead. The <table> markup is untouched: robot selects rows
+   as `.admin-table tbody tr:first-child a.btn-sm` and locates four tables by id, and Get
+   Text runs in Playwright strict mode, so a second parallel card markup would break all of
+   that. The column labels come from data-label, set by public/js/admin.js from the thead —
+   Chromium's innerText excludes generated content, so the ::before labels stay out of Get
+   Text too.
+
+   Opt out with .admin-table--scroll (inside a .table-responsive) where a grid still reads
+   better than one labelled line per value. .admin-table--kv is already label/value. */
+@media (max-width: 768px) {
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv),
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > tbody,
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > tbody > tr,
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > tbody > tr > td {
+    display: block;
+  }
+
+  /* Takes the members list's sort links with it — see the note in views/admin/members/list.pug.
+     Filtering survives: the view pills and the three selects are outside the table. */
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > thead {
+    display: none;
+  }
+
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > tbody > tr {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-card);
+    padding: 0.5rem 1rem;
+    margin-bottom: 0.75rem;
+  }
+
+  /* Inside a white panel a white card is invisible, so those keep the border only. The
+     members and payments lists sit straight on --page-bg and need the fill. */
+  .admin-panel .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > tbody > tr {
+    background: transparent;
+  }
+
+  /* .admin-table tr:hover td paints #f8f9fa, which greys the whole card on tap. */
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > tbody > tr:hover > td {
+    background: transparent;
+  }
+
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > tbody > tr > td {
+    grid-template-columns: 7rem minmax(0, 1fr);
+    gap: 0.75rem;
+    align-items: baseline;
+    /* Grid items stretch by default, which blew every status pill out to the full width of
+       the value column and made it read as a filled bar rather than a badge. */
+    justify-items: start;
+    padding: 0.375rem 0;
+    border-bottom: none;
+    overflow-wrap: anywhere;      /* long emails, referrer URLs */
+  }
+
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > tbody > tr > td[data-label] {
+    display: grid;
+  }
+
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > tbody > tr > td::before {
+    content: attr(data-label);
+    color: var(--text-muted);
+    font-weight: 600;
+    font-size: 0.8125rem;
+  }
+
+  /* A blank cell would otherwise leave its label stranded on a line of its own. */
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > tbody > tr > td:empty {
+    display: none;
+  }
+
+  /* Full-width cells: the actions column, and the colspan empty-state rows. periods/list
+     and campaigns/list both head their actions column with an empty th, so those cells get
+     no data-label at all and land here too. */
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > tbody > tr > td[colspan],
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > tbody > tr > td:has(.row-actions),
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > tbody > tr > td:has(> .btn-sm),
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > tbody > tr > td:has(> .inline-form) {
+    grid-template-columns: minmax(0, 1fr);
+    padding-top: 0.625rem;
+  }
+
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > tbody > tr > td[colspan]::before,
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > tbody > tr > td:has(.row-actions)::before,
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > tbody > tr > td:has(> .btn-sm)::before,
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) > tbody > tr > td:has(> .inline-form)::before {
+    display: none;
+  }
+
+  /* The actions sit on their own line at the foot of the card, at their natural width.
+     Stretching them edge to edge turned a one-word Edit link into a navy slab heavier than
+     the record it belonged to, and .btn-sm already clears --tap-target-sm. */
+  .admin-table:not(.admin-table--scroll):not(.admin-table--kv) .row-actions {
+    justify-content: flex-start;
+  }
+
+  /* Key/value tables: label over value. The fixed label columns — 160px on .detail-table,
+     14rem on --kv — left ~150px for the value on a 390px phone, which is what wrapped the
+     member's address onto three lines. */
+  .detail-table,
+  .detail-table > tbody,
+  .detail-table > tbody > tr,
+  .detail-table > tbody > tr > th,
+  .detail-table > tbody > tr > td,
+  .snapshot-table,
+  .snapshot-table > tbody,
+  .snapshot-table > tbody > tr,
+  .snapshot-table > tbody > tr > th,
+  .snapshot-table > tbody > tr > td,
+  .admin-table--kv,
+  .admin-table--kv > tbody,
+  .admin-table--kv > tbody > tr,
+  .admin-table--kv > tbody > tr > th,
+  .admin-table--kv > tbody > tr > td {
+    display: block;
+    width: auto;
+  }
+
+  .detail-table > tbody > tr > th,
+  .snapshot-table > tbody > tr > th,
+  .admin-table--kv > tbody > tr > th {
+    padding: 0 0 0.125rem;
+    white-space: normal;
+    border-bottom: none;
+    font-size: 0.8125rem;
+  }
+
+  .detail-table > tbody > tr > td,
+  .snapshot-table > tbody > tr > td,
+  .admin-table--kv > tbody > tr > td {
+    padding: 0 0 0.75rem;
+    margin-bottom: 0.75rem;
+    border-bottom: 1px solid var(--rule);
+  }
+
+  .detail-table > tbody > tr:last-child > td,
+  .snapshot-table > tbody > tr:last-child > td,
+  .admin-table--kv > tbody > tr:last-child > td {
+    margin-bottom: 0;
+    border-bottom: none;
+  }
 }

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -210,4 +210,26 @@ document.addEventListener('DOMContentLoaded', function () {
       select.form.submit();
     });
   });
+
+  // Column labels for the mobile card layout. Below 768px admin.css turns every row of a
+  // list table into a card and renders these as td::before, because a 5-to-9 column table
+  // on a phone otherwise overflows the document and scrolls the whole page sideways.
+  //
+  // Done here rather than as data-label in the templates: there are eighteen of these
+  // tables, and the heading is already in the thead. Runs at every width — the attribute is
+  // inert until the media query applies, so there is no resize listener and no reflow.
+  document.querySelectorAll('table.admin-table:not(.admin-table--scroll):not(.admin-table--kv)').forEach(function (table) {
+    var labels = Array.prototype.map.call(table.querySelectorAll(':scope > thead > tr > th'), function (th) {
+      // members/list.pug's sortTh appends ' \u25b2' / ' \u25bc' to the active column.
+      return th.textContent.replace(/[\u25b2\u25bc]/g, '').trim();
+    });
+    if (!labels.length) return;
+
+    table.querySelectorAll(':scope > tbody > tr').forEach(function (row) {
+      Array.prototype.forEach.call(row.children, function (cell, i) {
+        if (cell.colSpan > 1) return;   // the colspan empty-state rows have no column
+        if (labels[i]) cell.setAttribute('data-label', labels[i]);
+      });
+    });
+  });
 });

--- a/robot/tests/admin_mobile.robot
+++ b/robot/tests/admin_mobile.robot
@@ -1,0 +1,135 @@
+*** Settings ***
+Documentation     Phone-width layout guards for the admin UI.
+...
+...               The other suites all run at Playwright's default 1280x720, so nothing
+...               exercised the @media (max-width: 768px) rules. That is how the admin
+...               shipped with tables wide enough to overflow the *document* — with no
+...               scroll container, the whole page scrolled sideways, which made the panels
+...               look off-centre with a grey strip down the left even though they were
+...               centred. These tests fail on that layout.
+Resource          ../resources/common.resource
+Resource          ../resources/admin.resource
+Suite Setup       Start Test Server
+Suite Teardown    Stop Test Server
+Test Setup        Reset Test State
+Force Tags        admin    mobile
+
+*** Variables ***
+${PHONE_WIDTH}     390
+${PHONE_HEIGHT}    844
+@{ADMIN_PATHS}     /admin/dashboard    /admin/members    /admin/members/new
+...                /admin/announcements    /admin/gallery    /admin/bios
+...                /admin/payments    /admin/emails    /admin/emails/renewal
+...                /admin/reports/membership    /admin/campaigns
+...                /admin/contact-submissions    /admin/periods    /admin/settings
+...                /admin/admins    /admin/audit
+
+*** Test Cases ***
+Members List Fits A Phone
+    ${id}=    Seed Member    Danette    Sawin    danette.sawin@example.com
+    Login As Admin
+    Use Phone Viewport
+    Navigate To    /admin/members
+    Page Should Not Scroll Sideways
+
+Needs Attention View Fits A Phone
+    [Documentation]    The widest list in the app: the Signals column makes it eight columns.
+    ...    A failed payment on a pending member is what puts a row in this view at all —
+    ...    without one the table is not rendered and the test would pass on an empty page.
+    ${id}=    Seed Member    first_name=Dana    last_name=Declined    email=declined@example.com    status=pending
+    Seed Payment    ${id}    status=failed
+    Login As Admin
+    Use Phone Viewport
+    Navigate To    /admin/members?view=needs-attention
+    Wait For Elements State    .badge-attention    visible    timeout=10s
+    Page Should Not Scroll Sideways
+
+Member Record Fits A Phone
+    ${id}=    Seed Member    Danette    Sawin    danette.sawin@example.com
+    ...    address_street=419 Wood Duck Drive    address_city=Park City    address_zip=59063
+    Seed Payment    ${id}    amount_cents=5600
+    ${period}=    Get Current Period Id
+    Enroll Member    ${id}    ${period}
+    Seed Email Log    ${id}
+    Login As Admin
+    Use Phone Viewport
+    Navigate To    /admin/members/${id}
+    Page Should Not Scroll Sideways
+
+Payments List Fits A Phone
+    ${id}=    Seed Member    Danette    Sawin    danette.sawin@example.com
+    Seed Payment    ${id}    amount_cents=5600
+    Login As Admin
+    Use Phone Viewport
+    Navigate To    /admin/payments
+    Page Should Not Scroll Sideways
+
+Audit Log Fits A Phone
+    [Documentation]    The audit table opts out of the card layout, so its own
+    ...    .table-responsive wrapper has to keep the scrolling off the document.
+    Seed Member    Danette    Sawin    danette.sawin@example.com
+    Login As Admin
+    Use Phone Viewport
+    Navigate To    /admin/audit
+    Page Should Not Scroll Sideways
+
+Table Rows Carry Their Column Labels
+    [Documentation]    public/js/admin.js copies the thead into data-label, which
+    ...    td::before renders as the row label once the table is laid out as cards.
+    ${id}=    Seed Member    Danette    Sawin    danette.sawin@example.com
+    Seed Payment    ${id}    amount_cents=5600
+    Login As Admin
+    Use Phone Viewport
+    Navigate To    /admin/members/${id}
+    ${label}=    Get Attribute    css=#member-payments tbody tr:first-child td:nth-child(1)    data-label
+    Should Be Equal    ${label}    Amount
+    ${label}=    Get Attribute    css=#member-payments tbody tr:first-child td:nth-child(5)    data-label
+    Should Be Equal    ${label}    Date
+
+Sort Indicators Are Stripped From The Labels
+    [Documentation]    members/list.pug's sortTh appends an arrow to the active column, and
+    ...    it must not end up in the card label.
+    Seed Member    Danette    Sawin    danette.sawin@example.com
+    Login As Admin
+    Use Phone Viewport
+    Navigate To    /admin/members?sort=name&dir=asc
+    ${label}=    Get Attribute    .admin-table tbody tr:first-child td:nth-child(2)    data-label
+    Should Be Equal    ${label}    Name
+
+Every Admin Page Fits A Phone
+    [Documentation]    A sweep, so a table added to any admin page cannot quietly reintroduce
+    ...    the document-level sideways scroll. Every list is seeded first: an empty table is
+    ...    not rendered at all, and this would pass on the empty state.
+    ${id}=    Seed Member    first_name=Danette    last_name=Sawin    email=danette.sawin@example.com
+    ...    address_street=419 Wood Duck Drive    address_city=Park City    address_zip=59063
+    Seed Payment    ${id}    amount_cents=5600
+    Seed Email Log    ${id}
+    ${period}=    Get Current Period Id
+    Enroll Member    ${id}    ${period}
+    Seed Announcements    2
+    Seed Bios    2
+    Seed Gallery    2
+    Seed Campaign
+    Login As Admin
+    Use Phone Viewport
+    FOR    ${path}    IN    @{ADMIN_PATHS}
+        Navigate To    ${path}
+        # The error page does not extend the admin layout, so this also catches a path in
+        # the list above that has stopped resolving — otherwise the sweep would measure a
+        # 404 and happily report that it fits.
+        Wait For Elements State    .admin-page-title    visible    timeout=10s
+        Page Should Not Scroll Sideways    ${path}
+    END
+
+*** Keywords ***
+Use Phone Viewport
+    Set Viewport Size    ${PHONE_WIDTH}    ${PHONE_HEIGHT}
+
+Page Should Not Scroll Sideways
+    [Documentation]    scrollWidth against clientWidth, not innerWidth: clientWidth already
+    ...    excludes the vertical scrollbar, so the difference is the real overflow.
+    [Arguments]    ${where}=${EMPTY}
+    ${overflow}=    Evaluate JavaScript    ${None}
+    ...    () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+    Should Be True    ${overflow} <= 1
+    ...    ${where} overflows its viewport by ${overflow}px at ${PHONE_WIDTH}px wide

--- a/views/admin/audit.pug
+++ b/views/admin/audit.pug
@@ -17,8 +17,10 @@ block content
     if rows.length === 0
         p.empty-state No audit entries found.
     else
+        //- --scroll opts out of the mobile card layout in admin.css: the Changes cell holds
+        //- a nested table.audit-diff inside a <details>, which does not stack sensibly.
         .table-responsive
-            table.admin-table
+            table.admin-table.admin-table--scroll
                 thead
                     tr
                         th When

--- a/views/admin/campaigns/detail.pug
+++ b/views/admin/campaigns/detail.pug
@@ -95,19 +95,23 @@ block content
         if visits.length === 0
             p.text-muted No visits recorded yet.
         else
-            table#campaign-visits.admin-table
-                thead
-                    tr
-                        th Landed on
-                        th Referrer
-                        th Source / Medium
-                        th When
-                tbody
-                    each v in visits
+            //- --scroll opts out of the mobile card layout: a path, a referrer URL, a
+            //- source/medium and a timestamp read as a scannable grid, not as four
+            //- labelled lines per visit.
+            .table-responsive
+                table#campaign-visits.admin-table.admin-table--scroll
+                    thead
                         tr
-                            td= v.landing_path
-                            td.text-muted= v.referrer || 'direct'
-                            td.text-muted= [v.utm_source, v.utm_medium].filter(Boolean).join(' / ') || '—'
-                            td= v.created_at
+                            th Landed on
+                            th Referrer
+                            th Source / Medium
+                            th When
+                    tbody
+                        each v in visits
+                            tr
+                                td= v.landing_path
+                                td.text-muted= v.referrer || 'direct'
+                                td.text-muted= [v.utm_source, v.utm_medium].filter(Boolean).join(' / ') || '—'
+                                td= v.created_at
             p.text-muted Showing the 25 most recent. Visits are pruned after two years.
 

--- a/views/admin/members/list.pug
+++ b/views/admin/members/list.pug
@@ -3,6 +3,9 @@ extends ../layout
 block page_title
   | Members
 
+//- Sorting is desktop-only: below 768px admin.css hides the thead to lay each row out as a
+//- card, and these links go with it. The filters do not — the view pills and the three
+//- data-auto-submit selects sit outside the table.
 mixin sortTh(key, label)
   - const isActive = sort === key
   - const nextDir = isActive && dir === 'asc' ? 'desc' : 'asc'


### PR DESCRIPTION
Improves mobile formatting of tabular data in admin interface.

## Checklist
- [x] `npm run lint` passes
- [x] `npm test` passes
- [x] No `.env` or secrets committed
